### PR TITLE
Feature/add main pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1227,6 +1227,16 @@
         "fastq": "^1.6.0"
       }
     },
+    "@nuxt/opencollective": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.3.0.tgz",
+      "integrity": "sha512-Vf09BxCdj1iT2IRqVwX5snaY2WCTkvM0O4cWWSO1ThCFuc4if0Q/nNwAgCxRU0FeYHJ7DdyMUNSdswCLKlVqeg==",
+      "requires": {
+        "chalk": "^2.4.2",
+        "consola": "^2.10.1",
+        "node-fetch": "^2.6.0"
+      }
+    },
     "@soda/friendly-errors-webpack-plugin": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@soda/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.1.tgz",
@@ -2256,7 +2266,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -2726,6 +2735,18 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.0.tgz",
       "integrity": "sha512-Z93QoXvodoVslA+PWNdk23Hze4RBYIkpb5h8I2HY2Tu2h7A0LpAgLcyrhrSUyo2/Oxm2l1fRZPs1e5hnxnliXA=="
     },
+    "bootstrap-vue": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.15.0.tgz",
+      "integrity": "sha512-ncxWkDG0mKFVot314wWKJELi+ESO7k6ngV//qvJFs9iVzlFI8Hx3rBVbpcPW2vrJ+0vitH8N2SOwn4fdQ3frMQ==",
+      "requires": {
+        "@nuxt/opencollective": "^0.3.0",
+        "bootstrap": ">=4.5.0 <5.0.0",
+        "popper.js": "^1.16.1",
+        "portal-vue": "^2.1.7",
+        "vue-functional-data-merge": "^3.1.0"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3176,7 +3197,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -3188,6 +3208,40 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "chart.js": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.3.tgz",
+      "integrity": "sha512-+2jlOobSk52c1VU6fzkh3UwqHMdSlgH1xFv9FKMqHiNCpXsGPQa/+81AFa+i3jZ253Mq9aAycPwDjnn1XbRNNw==",
+      "requires": {
+        "chartjs-color": "^2.1.0",
+        "moment": "^2.10.2"
+      }
+    },
+    "chartjs-color": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
+      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+      "requires": {
+        "chartjs-color-string": "^0.6.0",
+        "color-convert": "^1.9.3"
+      }
+    },
+    "chartjs-color-string": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+      "requires": {
+        "color-name": "^1.0.0"
+      }
+    },
+    "chartjs-plugin-annotation": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-0.5.7.tgz",
+      "integrity": "sha1-G/DjAZmmqf+Yic4PN6HnVagNEL8=",
+      "requires": {
+        "chart.js": "^2.4.0"
+      }
     },
     "check-error": {
       "version": "1.0.2",
@@ -3682,7 +3736,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -3690,8 +3743,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.3",
@@ -3853,6 +3905,11 @@
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
       "dev": true
+    },
+    "consola": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.14.0.tgz",
+      "integrity": "sha512-A2j1x4u8d6SIVikhZROfpFJxQZie+cZOfQMyI/tu2+hWXe8iAv7R6FW6s6x04/7zBCst94lPddztot/d6GJiuQ=="
     },
     "console-browserify": {
       "version": "1.2.0",
@@ -5267,8 +5324,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.3",
@@ -6454,8 +6510,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -9133,6 +9188,11 @@
         "semver": "^5.7.0"
       }
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "node-forge": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
@@ -9839,6 +9899,11 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
       "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+    },
+    "portal-vue": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.7.tgz",
+      "integrity": "sha512-+yCno2oB3xA7irTt0EU5Ezw22L2J51uKAacE/6hMPMoO/mx3h4rXFkkBkT4GFsMDv/vEe8TNKC3ujJJ0PTwb6g=="
     },
     "portfinder": {
       "version": "1.0.26",
@@ -12037,7 +12102,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -12805,6 +12869,11 @@
           }
         }
       }
+    },
+    "vue-functional-data-merge": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-3.1.0.tgz",
+      "integrity": "sha512-leT4kdJVQyeZNY1kmnS1xiUlQ9z1B/kdBFCILIjYYQDqZgLqCLa0UhjSSeRX6c3mUe6U5qYeM8LrEqkHJ1B4LA=="
     },
     "vue-hot-reload-api": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   },
   "dependencies": {
     "bootstrap": "^4.3.1",
+    "bootstrap-vue": "^2.15.0",
     "core-js": "^3.6.5",
+    "chart.js": "^2.8.0",
+    "chartjs-plugin-annotation": "^0.5.7",
     "jquery": "^3.5.0",
     "lodash": "^4.17.13",
     "moment": "^2.22.1",

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="apple-touch-icon" href="https://cdn.lco.global/mainstyle/img/favicon.png">
     <link rel="shortcut icon" type="image/png" href="https://cdn.lco.global/mainstyle/img/favicon-trans.png"/>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
     <link href='https://cdn.lco.global/mainstyle/css/affogato-1.0.0.css' rel="stylesheet">
     <link href='https://cdn.lco.global/mainstyle/css/lco-1.0.0.css' rel="stylesheet">

--- a/src/App.vue
+++ b/src/App.vue
@@ -100,17 +100,18 @@
 <script>
 import moment from 'moment';
 
-import { testProfileData, userIsAuthenticated } from '@/testData.js';
+import { getTestProfileData } from '@/testData.js';
 
 export default {
   name: "App",
   data: function() {
+    let testProfileData = getTestProfileData(this.$route.query);
     return {
       bootstrap_messages: "",
       year: moment.utc().format("YYYY"),
       // TODO: Update to derive from actual profile data
-      profile: testProfileData,
-      userIsAuthenticated: userIsAuthenticated
+      profile: testProfileData[0],
+      userIsAuthenticated: testProfileData[1]
     };
   },
   computed: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,7 +15,7 @@
             Observation
             <br />Portal
           </router-link>
-          <span v-if="user.profile.simple_interface" class="basic">basic mode</span>
+          <span v-if="simpleInterface" class="basic">basic mode</span>
         </div>
       </div>
       <button
@@ -51,13 +51,13 @@
           </li>
         </ul>
         <ul class="nav navbar-nav navbar-right">
-          <li v-if="user.is_authenticated" class="dropdown nav-item">
+          <li v-if="userIsAuthenticated" class="dropdown nav-item">
             <a
               class="dropdown-toggle nav-link"
               id="userNavOptions"
               data-toggle="dropdown"
               href="#"
-            >{{ user.username }}</a>
+            >{{ profile.username }}</a>
             <div class="dropdown-menu" aria-labelledby="userNavOptions">
               <router-link class="dropdown-item" :to="{name: 'profile'}">Profile</router-link>
               <router-link class="dropdown-item" :to="{name: 'logout'}">Logout</router-link>
@@ -98,7 +98,9 @@
 </template>
 
 <script>
-import moment from "moment";
+import moment from 'moment';
+
+import { testProfileData, userIsAuthenticated } from '@/testData.js';
 
 export default {
   name: "App",
@@ -106,14 +108,19 @@ export default {
     return {
       bootstrap_messages: "",
       year: moment.utc().format("YYYY"),
-      user: {
-        username: "isaac_newton",
-        is_authenticated: true,
-        profile: {
-          simple_interface: false
-        }
-      }
+      // TODO: Update to derive from actual profile data
+      profile: testProfileData,
+      userIsAuthenticated: userIsAuthenticated
     };
+  },
+  computed: {
+    simpleInterface: function() {
+      if (this.profile.profile && this.profile.profile.simple_interface) {
+        return true;
+      } else {
+        return false;
+      }
+    }
   }
 };
 </script>

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -145,13 +145,11 @@ a:hover {
     border: 1px solid #EFF0EC;
     min-height: 75px;
     margin: 0px;
-
 }
 
 .requestgroup-title {
     font-size: 1.2em;
     font-weight: 900;
-    margin-left: 4px;
 }
 
 .requestgroup-success {
@@ -172,10 +170,6 @@ a:hover {
 
 .requestgroup-info {
     background: linear-gradient(to right,#31708f 0,#31708f 10px,#fff 10px,#fff 100%) no-repeat;
-}
-
-.requestgroup-block > p {
-    margin: 3px;
 }
 
 .requestgroup-block.border-right {
@@ -199,9 +193,9 @@ a:hover {
 
 .request-count {
     font-size: 1.9em;
-    margin-top: 15px;
-    margin-bottom: 5px;
+    padding-top: 15px;
 }
+
 .request-additional {
     padding-top: 20px;
     font-size: 1.5em;
@@ -283,6 +277,11 @@ a:hover {
     color: #009cc3;
 }
 
+a {
+    color: #009cc3;
+    text-decoration: none;
+}
+
 .pagination > .active > a {
     background-color: #009cc3;
 }
@@ -307,8 +306,7 @@ a:hover {
     padding: 0 !important;
 }
 
-
- .btn-outline-secondary {
+.btn-outline-secondary {
     border-color: #bababa;
     color: #000000;
 }

--- a/src/components/Contention.vue
+++ b/src/components/Contention.vue
@@ -1,0 +1,163 @@
+<template>
+  <b-container class="contention my-4">
+    <b-row>
+      <b-col cols="auto" class="p-0 pb-1">
+        <b-form-group
+          id="contention-instrument-formgroup" 
+          class="my-auto"
+          label="Instrument"
+          label-size="sm"
+          label-align-sm="right"
+          label-cols-sm="5"
+          label-for="instrument"
+          label-class="font-weight-bolder"
+        >
+          <b-form-select
+            id="contention-instrument-select" 
+            size="sm"
+            v-model="instrument"
+            field="instrument"
+            :options="instruments"
+          />
+        </b-form-group>
+      </b-col>
+      <b-col>
+        <data-load-help
+          :dataAvailable="dataAvailable"
+          :loadingDataFailed="loadingDataFailed"
+          :isLoading="isLoading"
+        />
+      </b-col>
+    </b-row>
+    <canvas id="contentionplot" width="400" height="200"></canvas>
+  </b-container>
+</template>
+<script>
+  import Chart from 'chart.js';
+  import $ from 'jquery';
+
+  import DataLoadHelp from '@/components/util/DataLoadHelp.vue';
+  import { colorPalette } from '@/utils.js';
+
+  export default {
+    name: 'Contention',
+    props: {
+      instruments: {
+        type: Array,
+        required: true,
+        description: 'Array of objects with value and text fields, used for instrument select field'
+      }
+    },
+    components: {
+      DataLoadHelp
+    },
+    data: function() {
+      return {
+        loadingDataFailed: false,
+        isLoading: false,
+        runningQuery: null,
+        instrument: '',
+        rawData: [],
+        data: {
+          labels: Array.apply(null, {length: 24}).map(Number.call, Number),
+          datasets: []
+        }
+      };
+    },
+    computed: {
+      toChartData: function() {
+        let datasets = {};
+        for (let ra = 0; ra < this.rawData.length; ra++) {
+          for (let proposal in this.rawData[ra]) {
+            if (!Object.prototype.hasOwnProperty.call(datasets, proposal)) {  
+              datasets[proposal] = Array.apply(null, Array(24)).map(Number.prototype.valueOf, 0);  // fills array with 0s
+            }
+            datasets[proposal][ra] = this.rawData[ra][proposal] / 3600;
+          }
+        }
+        let grouped = [];
+        let color = 0;
+        for (let prop in datasets) {
+          grouped.push({label: prop, data: datasets[prop], backgroundColor: colorPalette[color]});
+          color++;
+        }
+        return grouped;
+      },
+      dataAvailable: function() {
+        for (let bin in this.rawData) {
+          for (let proposal in this.rawData[bin]) {
+            if (this.rawData[bin][proposal] > 0) {
+              return true;
+            }
+          }
+        }
+        return false;
+      }
+    },
+    created: function() {
+      this.instrument = '1M0-SCICAM-SINISTRO';
+    },
+    watch: {
+      instrument: function(instrument) {
+        if (this.runningQuery){
+          this.runningQuery.abort();
+        }
+        this.rawData = [];
+        this.isLoading = true;
+        let that = this;
+        this.runningQuery = $.getJSON(this.observationPortalApiUrl + '/api/contention/' + instrument + '/', function(data) {
+          that.rawData = data.contention_data;
+          that.data.datasets = that.toChartData;
+          that.chart.update();
+        }).done(function() {
+          that.loadingDataFailed = false;
+          that.runningQuery = null;
+        }).fail(function(res, textStatus) {
+          if (textStatus !== 'abort'){
+            that.loadingDataFailed = true;
+          }
+        }).always(function(res, textStatus) {
+          if (textStatus !== 'abort'){
+            that.isLoading = false;
+          }
+          else{
+            that.runningQuery = null;
+          }
+        });
+      }
+    },
+    mounted: function() {
+      let that = this;
+      let ctx = document.getElementById('contentionplot');
+      this.chart = new Chart(ctx, {
+        type: 'bar',
+        data: that.data,
+        options: {
+          scales: {
+            xAxes: [{
+              stacked: true,
+              scaleLabel: {
+                display: true,
+                labelString: 'Right Ascension'
+              }
+            }],
+            yAxes: [{
+              stacked: true,
+              scaleLabel: {
+                display: true,
+                labelString: 'Total Requested Hours'
+              }
+            }]
+          },
+          tooltips: {
+            callbacks: {
+              label: function(tooltipItem) {
+                return that.data.datasets[tooltipItem.datasetIndex].label + ' ' + tooltipItem.yLabel.toFixed(3);
+              }
+            }
+          }
+        }
+      });
+    }
+  };
+</script>

--- a/src/components/Pressure.vue
+++ b/src/components/Pressure.vue
@@ -1,0 +1,350 @@
+<template>
+  <b-container class="pressure my-4">
+    <b-row>
+      <b-col cols="auto" class="p-0 pb-1">
+        <b-form-group
+          id="pressure-instrument-formgroup" 
+          class="my-auto"
+          label="Instrument"
+          label-size="sm"
+          label-align-sm="right"
+          label-cols-sm="5"
+          label-for="instrument"
+          label-class="font-weight-bolder"
+        >
+          <b-form-select
+            id="pressure-instrument-select" 
+            size="sm"
+            v-model="instrument"
+            field="instrument"
+            :options="instrumentTypeOptions"
+          />
+        </b-form-group>
+      </b-col>
+      <b-col cols="auto" class="p-0 pb-2">
+        <b-form-group
+          id="pressure-site-formgroup" 
+          class="my-auto"
+          label="Site"
+          label-size="sm"
+          label-align-sm="right"
+          label-cols-sm="2"
+          label-for="site"
+          label-class="font-weight-bolder"
+        >
+          <b-form-select
+            id="pressure-site-select" 
+            size="sm"
+            v-model="site"
+            field="site"
+            :options="siteOptions"
+          />
+        </b-form-group>
+      </b-col>
+      <b-col>
+        <data-load-help
+          :dataAvailable="dataAvailable"
+          :loadingDataFailed="loadingDataFailed"
+          :isLoading="isLoading"
+        />
+      </b-col>
+    </b-row>
+    <canvas id="pressureplot" width="400" height="200"></canvas>
+  </b-container>
+</template>
+<script>
+  import 'chartjs-plugin-annotation';
+  import Chart from 'chart.js';
+  import $ from 'jquery';
+
+  import DataLoadHelp from '@/components/util/DataLoadHelp.vue';
+  import { colorPalette } from '@/utils.js';
+
+  export default {
+    name: 'pressure',
+    components: {
+      DataLoadHelp
+    },
+    props: {
+      instruments: {
+        type: Array,
+        required: true,
+        description: 'Array of objects with value and text fields, used for instrument select field'
+      }
+    },
+    data: function() {
+      return {
+        instrument: '',
+        loadingDataFailed: false,
+        isLoading: false,
+        site: '',
+        maxY: 1,
+        runningQuery: null,
+        rawData: [],
+        rawSiteData: [],
+        siteNights: [],
+        siteOptions: [
+          {value: '', text: 'All'},
+          {value: 'coj', text: 'Siding Spring, Australia (coj)'},
+          {value: 'cpt', text: 'Sutherland, South Africa (cpt)'},
+          {value: 'elp', text: 'McDonald, Texas (elp)'},
+          {value: 'lsc', text: 'Cerro Tololo, Chile (lsc)'},
+          {value: 'ogg', text: 'Maui, Hawaii (ogg)'},
+          {value: 'sor', text: 'Cerro Pachón, Chile (sor)'},
+          {value: 'tfn', text: 'Tenerife, Canary Islands (tfn)'},
+          {value: 'tlv', text: 'Wise, Israel (tlv)'}
+        ],
+        data: {
+          datasets: [],
+          labels: Array.apply(null, {length: 24 * 4 + 1}).map(Number.call, Number).map(function(x){ return (x / 4).toString(); })
+        }
+      };
+    },
+    computed: {
+      instrumentTypeOptions: function() {
+        let options = [{value: '', text: 'All'}]
+        for (let idx in this.instruments) {
+          options.push(this.instruments[idx]);
+        }
+        return options;
+      },
+      toChartData: function() {
+        let datasets = {};
+        for (let time = 0; time < this.rawData.length; time++) {
+          for (let proposal in this.rawData[time]) {
+            if (!Object.prototype.hasOwnProperty.call(datasets, proposal)) {
+              datasets[proposal] = Array.apply(null, Array(24 * 4)).map(Number.prototype.valueOf, 0);  // fills array with 0s
+            }
+            datasets[proposal][time] = this.rawData[time][proposal];
+          }
+        }
+        let grouped = [];
+        let color = 0;
+        for (let prop in datasets) {
+          grouped.push({label: prop, data: datasets[prop], backgroundColor: colorPalette[color], type: 'bar'});
+          color++;
+        }
+        return grouped;
+      },
+      maxPressureInGraph: function() {
+        var maxPressure = 0;
+        for (var time = 0; time < this.rawData.length; time++) {
+          var pressure = 0;
+          for(var proposal in this.rawData[time]){
+            pressure += this.rawData[time][proposal];
+          }
+          if (pressure > maxPressure) {
+            maxPressure = pressure;
+          }
+        }
+        return maxPressure;
+      },
+      dataAvailable: function() {
+        for (let bin in this.rawData) {
+          for (let proposal in this.rawData[bin]) {
+            if (this.rawData[bin][proposal] > 0) {
+              return true;
+            }
+          }
+        }
+        return false;
+      }
+    },
+    created: function() {
+      this.fetchData();
+    },
+    methods: {
+      toSiteNightData: function() {
+        let nights = [];
+        let siteSpacing = 0.6;
+        let height = this.maxY + siteSpacing * 2;
+        for (let i = 0; i < this.rawSiteData.length; i++) {
+          let longSiteName = '';
+          for (let so in this.siteOptions) {
+            if (this.siteOptions[so].value == this.rawSiteData[i].name) {
+              longSiteName = this.siteOptions[so].text;
+              break;
+            }
+          }
+          nights.push({
+            name: longSiteName,
+            start: this.roundToOneQuarter(this.rawSiteData[i].start).toString(),
+            end: this.roundToOneQuarter(this.rawSiteData[i].stop).toString(),
+            height: height
+          });
+          height += siteSpacing;
+        }
+        this.maxY = Math.ceil(height);
+        return nights;
+      },
+      fetchData: function() {
+        if (this.runningQuery){
+          this.runningQuery.abort();
+        }
+        this.isLoading = true;
+        this.rawData = [];
+        this.rawSiteData = [];
+        let urlstring = this.observationPortalApiUrl + '/api/pressure/?x=0';
+        if (this.site) urlstring += ('&site=' + this.site);
+        if (this.instrument) urlstring += ('&instrument=' + this.instrument);
+        let that = this;
+        this.runningQuery = $.getJSON(urlstring, function(data) {
+          that.rawData = data.pressure_data;
+          that.rawSiteData = data.site_nights;
+          that.maxY = that.maxPressureInGraph;
+          that.siteNights = that.toSiteNightData();
+          that.data.datasets = that.toChartData;
+        }).done(function() {
+          that.loadingDataFailed = false;
+          that.runningQuery = null;
+        }).fail(function(res, textStatus) {
+          if (textStatus !== 'abort'){
+            that.loadingDataFailed = true;
+          }
+        }).always(function(res, textStatus) {
+          if (textStatus !== 'abort'){
+            that.isLoading = false;
+          }
+          else{
+            that.runningQuery = null;
+          }
+        });
+      },
+      updateChart: function() {
+        this.chart.options.siteNights = this.siteNights;
+        this.chart.options.scales.yAxes[0].ticks.max = this.maxY;
+        this.chart.update();
+      },
+      roundToOneQuarter: function(n) {
+        return Math.ceil(n * 4) / 4;
+      }
+    },
+    watch: {
+      instrument: function() {
+        this.fetchData();
+      },
+      site: function() {
+        this.fetchData();
+      }
+    },
+    updated: function() {
+      this.updateChart();
+    },
+    mounted: function() {
+      Chart.pluginService.register({
+        afterDraw: function(chart) {
+
+          let xScale = chart.scales['x-axis-0'];
+          let yScale = chart.scales['y-axis-0'];
+          let startHourOfGraph = '0';
+          let endHourOfGraph = '24';
+          let textPadding = 3;
+          let textX;
+          let end;
+          let start;
+          let height;
+          let textHeight;
+          let tickWidth;
+          let night;
+
+          if (chart.options.siteNights) {
+            for (var i = 0; i < chart.options.siteNights.length; i++) {
+              night = chart.options.siteNights[i];
+
+              height = yScale.getPixelForValue(night.height);
+              start = xScale.getPixelForValue(night.start);
+              end = xScale.getPixelForValue(night.end);
+              textHeight = height - 14;
+
+              textX = (start + end) / 2;
+              tickWidth = 8;
+
+              // Draw the main site-night line.
+              chart.chart.ctx.strokeStyle = 'black';
+              chart.chart.ctx.lineWidth = 2;
+              chart.chart.ctx.beginPath();
+              chart.chart.ctx.moveTo(start, height);
+              chart.chart.ctx.lineTo(end, height);
+              chart.chart.ctx.stroke();
+
+              // Draw the tick at the end of the left side of the line.
+              chart.chart.ctx.beginPath();
+              chart.chart.ctx.moveTo(start, height - tickWidth / 2);
+              chart.chart.ctx.lineTo(start, height + tickWidth / 2);
+              chart.chart.ctx.stroke();
+
+              // Draw the tick at the end of the right side of the line.
+              chart.chart.ctx.beginPath();
+              chart.chart.ctx.moveTo(end, height - tickWidth / 2);
+              chart.chart.ctx.lineTo(end, height + tickWidth / 2);
+              chart.chart.ctx.stroke();
+
+              // Add the label to the line.
+              chart.chart.ctx.fillStyle = 'black';
+              chart.chart.ctx.textAlign = 'center';
+              if (night.start === startHourOfGraph){
+                textX = start + textPadding;
+                chart.chart.ctx.textAlign = 'left';
+              }
+              if (night.end === endHourOfGraph){
+                textX = end - textPadding;
+                chart.chart.ctx.textAlign = 'right';
+              }
+              chart.chart.ctx.fillText(night.name, textX, textHeight);
+            }
+          }
+        }
+      });
+      let that = this;
+      let ctx = document.getElementById('pressureplot').getContext('2d');
+
+      this.chart = new Chart(ctx, {
+        type: 'bar',
+        data: that.data,
+        options: {
+          annotation: {
+            annotations: [{
+              type: 'line',
+              mode: 'horizontal',
+              scaleID: 'y-axis-0',
+              value: '1.0',
+              borderColor: 'black',
+              borderDash: [5, 8],
+              borderWidth: 4,
+            }]
+          },
+          scales:{
+            xAxes: [{
+              stacked: true,
+              gridLines: {
+                offsetGridLines: false
+              },
+              scaleLabel: {
+                display: true,
+                labelString: 'Hours From Now'
+              },
+              ticks: {
+                maxTicksLimit: 25,
+                maxRotation: 0,
+              }
+            }],
+            yAxes: [{
+              stacked: true,
+              scaleLabel: {
+                display: true,
+                labelString: 'Pressure'
+              }
+            }]
+          },
+          tooltips: {
+            callbacks: {
+              label: function(tooltipItem) {
+                return that.data.datasets[tooltipItem.datasetIndex].label + ' ' + tooltipItem.yLabel.toFixed(3);
+              }
+            }
+          }
+        }
+      });
+    }
+  };
+</script>

--- a/src/components/RequestgroupsList.vue
+++ b/src/components/RequestgroupsList.vue
@@ -273,7 +273,7 @@ import $ from 'jquery';
 import _ from 'lodash';
 
 import { timeFromNow, formatDate, copyObject, stateToBsClass } from '@/utils.js';
-import { testProfileData } from '@/testData.js';
+import { getTestProfileData } from '@/testData.js';
 
 export default {
   name: 'RequestgroupsList',
@@ -341,6 +341,7 @@ export default {
       limit: 20,
       offset: 0
     }
+    let testProfileData = getTestProfileData(this.$route.query);
     return {
       orderOptions: orderOptions,
       stateOptions: stateOptions,
@@ -351,7 +352,7 @@ export default {
         { key: 'requestgroupInfo', tdClass: 'p-0 m-0', thClass: 'border-0' },
       ],
       // TODO: Replace with actual profile data
-      profile: testProfileData,
+      profile: testProfileData[0],
       isBusy: false,
       errors: [],
       currentPage: 1,
@@ -445,8 +446,12 @@ export default {
     updateRequestgroups: function() {
       this.setUserIfAuthoredOnly();
       this.getRequestgroups();
-      if (!_.isEqual(this.rgQueryParams, this.$route.query)) {
-        this.$router.push({ query: this.rgQueryParams });
+      let newQueryParams = copyObject(this.$route.query);
+      for (let rgKey in this.rgQueryParams) {
+        newQueryParams[rgKey] = this.rgQueryParams[rgKey];
+      }
+      if (!_.isEqual(newQueryParams, this.$route.query)) {
+        this.$router.push({ query: newQueryParams });
       }
     },
     onSubmit: function(event) {

--- a/src/components/RequestgroupsList.vue
+++ b/src/components/RequestgroupsList.vue
@@ -1,0 +1,473 @@
+<template>
+  <b-container class="p-0">
+    <b-row>
+      <b-col md="9" cols="12">
+        <p class="title">Submitted Observation Requests</p>
+      </b-col>
+      <b-col md="3" cols="12">
+        <b-dropdown 
+          id="dropdown-rg-query-params"
+          variant="outline-secondary"
+          block
+        >
+          <template v-slot:button-content>
+            <i class="fa fa-filter"></i> Filter List
+          </template>
+          <b-dropdown-form>
+            <b-form @submit="onSubmit" @reset="onReset">
+              <b-form-group
+                id="input-group-order"
+                label-for="input-order"
+                label-class="m-0"
+                class="my-2"
+              >
+                <template v-slot:label>
+                  <i class="fa fa-sort"></i> Sort
+                </template>
+                <b-form-select
+                  id="input-order"
+                  v-model="rgQueryParams.order"
+                  :options="orderOptions"
+                  size="sm"
+                ></b-form-select>
+              </b-form-group>
+              <b-form-group
+                id="input-group-state"
+                label-for="input-state"
+                label-class="m-0"
+                class="my-2"
+              >
+                <template v-slot:label>
+                  <i class="fas fa-sync"></i> State
+                </template>
+                <b-form-select
+                  id="input-state"
+                  v-model="rgQueryParams.state"
+                  :options="stateOptions"
+                  size="sm"
+                ></b-form-select>
+              </b-form-group>
+              <b-form-group 
+                id="input-group-name" 
+                label-for="input-name"
+                label-class="m-0"
+                class="my-2"
+              >
+                <b-form-input
+                  id="input-name"
+                  v-model="rgQueryParams.name"
+                  placeholder="Name contains"
+                  size="sm"
+                ></b-form-input>
+                <template v-slot:label>
+                  <i class="fa fa-paragraph"></i> Name Contains
+                </template>
+              </b-form-group>
+              <b-form-group 
+                id="input-group-target" 
+                label-for="input-target"
+                label-class="m-0"
+                class="my-2"
+              >
+                <b-form-input
+                  id="input-target"
+                  v-model="rgQueryParams.target"
+                  placeholder="Target Name Contains"
+                  size="sm"
+                ></b-form-input>
+                <template v-slot:label>
+                  <i class="fa fa-crosshairs"></i> Target Name Contains
+                </template>
+              </b-form-group>
+              <b-form-group
+                id="input-group-proposal"
+                label-for="input-proposal"
+                label-class="m-0"
+                class="my-2"
+              >
+                <template v-slot:label>
+                  <i class="fa fa-users"></i> Proposal
+                </template>
+                <b-form-select
+                  id="input-proposal"
+                  v-model="rgQueryParams.proposal"
+                  :options="proposalOptions"
+                  size="sm"
+                ></b-form-select>
+              </b-form-group>
+              <b-form-group 
+                id="input-group-created-after" 
+                label-for="input-created-after"
+                label-class="m-0"
+                class="my-2"
+              >
+                <b-form-input
+                  id="input-created-after"
+                  v-model="rgQueryParams.created_after"
+                  type="date"
+                  size="sm"
+                ></b-form-input>
+                <template v-slot:label>
+                  <i class="fa fa-calendar"> <i class="fa fa-arrow-right"></i> </i> Submitted After
+                </template>
+              </b-form-group>
+              <b-form-group 
+                id="input-group-created-before" 
+                label-for="input-created-before"
+                label-class="m-0"
+                class="my-2"
+              >
+                <b-form-input
+                  id="input-created-before"
+                  v-model="rgQueryParams.created_before"
+                  type="date"
+                  size="sm"
+                ></b-form-input>
+                <template v-slot:label>
+                  <i class="fa fa-arrow-left"></i> <i class="fa fa-calendar"></i> Submitted Before 
+                </template>
+              </b-form-group>
+              <b-form-group 
+                id="input-group-user" 
+                label-for="input-user"
+                label-class="m-0"
+                class="my-2"
+              >
+                <b-form-input
+                  id="input-user"
+                  v-model="rgQueryParams.user"
+                  placeholder="Username Contains"
+                  size="sm"
+                ></b-form-input>
+                <template v-slot:label>
+                  <i class="fa fa-user"></i> Username Contains
+                </template>
+              </b-form-group>
+              <b-dropdown-divider></b-dropdown-divider>
+              <b-button-group class="mx-4">
+                <b-button type="submit" variant="outline-info"><span class="text-nowrap">Filter Results</span></b-button>
+                <b-button type="reset" variant="outline-danger"><span class="text-nowrap">Clear All Fields</span></b-button>
+              </b-button-group>
+            </b-form>
+          </b-dropdown-form>
+        </b-dropdown>
+      </b-col>
+      <b-alert v-for="error in errors" :key="error" show variant="danger" class="w-100">
+        <i class="fas fa-exclamation-circle"></i> {{ error }}
+      </b-alert>
+    </b-row>
+    <div>
+      <b-table 
+        id="requestgroups-table"
+        :items="requestgroups.results"
+        :fields="fields"
+        :tbody-tr-class="requestGroupRowClass"
+        :busy="isBusy"
+        small
+        show-empty
+      >
+        <template v-slot:head(requestgroupInfo)>
+          <b-row>
+            <b-col md="4" cols="12">
+              <small>User Info</small>
+            </b-col>
+            <b-col md="4" cols="12">
+              <small>State Info</small>
+            </b-col>
+            <b-col md="4" cols="12">
+              <small># Requests / Pending / Failed / Complete</small>
+            </b-col>
+          </b-row>
+        </template>
+        <template v-slot:table-busy>
+          <br/>
+          <div class="text-center my-2">
+            <i class="fa fa-spin fa-spinner"></i> Loading observation requests...
+          </div>
+          <br/>
+        </template>
+        <template v-slot:empty>
+          <div class="empty-requests">
+            <center>
+              <!-- TODO: Translate this -->
+              <h2>No observation requests found.</h2>
+              <div v-if="profile.proposals.length > 0">
+                <!-- TODO: Translate this, and also, is this really a link to the create page? It was originally href=#, but that doesn't make sense -->
+                <router-link class="btn btn-success btn-lg" :to="{name: 'create'}">Submit an Observation Request</router-link>
+              </div>
+              <div v-else>
+                <h2> You are not a member of any proposals yet.</h2>
+                <p>Only users with at least one active proposal may submit observation requests.</p>
+                <!-- TODO: Translate this -->
+                <router-link class="btn btn-success btn-lg" :to="{name: 'apply'}">Submit a new proposal</router-link>
+              </div>
+              <h3>Need help?</h3>
+              <a href="https://lco.global/documentation/">View the documentation</a> or <a href="mailto:scisupport@lco.global">contact support</a>.
+            </center>
+          </div>
+        </template>
+        <template v-slot:cell(requestgroupInfo)="data">
+          <b-row class="mx-0">
+            <b-col md="8" cols="12" class="px-3">
+              <router-link class="requestgroup-title" :to="{name: 'requestgroupsDetail', params: {id: data.item.id} }">
+                {{ data.item.name | valueOrDefault('Unnamed Request')}}
+              </router-link>
+              <b-row>
+                <b-col class="pr-1">
+                  <div class="requestgroup-details requestgroup-block border-right">
+                    <div><i class="fa fa-fw fa-user"></i> {{ data.item.submitter }}</div>
+                    <div><i class="fa fa-fw fa-users"></i> <router-link :to="{name: 'proposalsDetail', params: {id: data.item.proposal}}">{{ data.item.proposal }}</router-link></div>
+                  </div>
+                </b-col>
+                <b-col class="p-0">
+                  <div class="requestgroup-details requestgroup-block">
+                    <div :class="data.item.state | stateToBsClass('text')"><i class="fa fa-fw" :class="data.item.state | startToIcon"></i>{{ data.item.state }}</div>
+                    <div><i class="fa fa-fw fa-calendar"></i> <span class="tool-tip" :title="data.item.modified | timeFromNow">{{ data.item.modified | formatDate }}</span></div>
+                  </div>
+                </b-col>
+              </b-row>
+            </b-col>
+            <b-col md="1" cols="12" class="request-count request-block">
+              <center>{{ data.item.requests.length }}</center>
+            </b-col>
+            <b-col md="1" cols="12" class="request-count request-block text-neutral">
+              <center>{{ data.item | requestStateCount('PENDING') }}</center>
+            </b-col>
+            <b-col md="1" cols="12" class="request-count request-block text-danger">
+              <center>{{ data.item | requestStateCount('WINDOW_EXPIRED') }}</center>
+            </b-col>
+            <b-col md="1" cols="12" class="request-count request-block text-success">
+              <center>{{ data.item | requestStateCount('COMPLETED') }}</center>
+            </b-col>
+          </b-row>
+        </template>
+      </b-table>
+      <b-row class="row">
+        <b-col md="9" cols="12">
+          <b-pagination
+            v-model="currentPage"
+            :total-rows="requestgroups.count"
+            :per-page="rgQueryParams.limit"
+            aria-controls="requestgroups-table"
+          ></b-pagination>
+        </b-col>
+        <b-col md="3" cols="12">
+          <b-form-group
+            label-for="perPageSelect"
+          >
+            <b-form-select
+              v-model="rgQueryParams.limit"
+              id="perPageSelect"
+              :options="perPageOptions"
+            ></b-form-select>
+          </b-form-group>
+        </b-col>
+      </b-row>
+    </div>
+  </b-container>
+</template>
+<script>
+import $ from 'jquery';
+import _ from 'lodash';
+
+import { timeFromNow, formatDate, copyObject, stateToBsClass } from '@/utils.js';
+import { testProfileData } from '@/testData.js';
+
+export default {
+  name: 'RequestgroupsList',
+  filters: {
+    requestStateCount: function(requestgroup, state) {
+      let count = 0;
+      for (let request of requestgroup.requests) {
+        if (request.state === state) {
+          count++;
+        }
+      }
+      return count;
+    },
+    stateToBsClass: function(state, prefix) {
+      return stateToBsClass(state, prefix);
+    },
+    startToIcon: function(state) {
+      let stateMap = {
+          'PENDING': 'sync',
+          'SCHEDULED': 'sync',
+          'COMPLETED': 'check',
+          'WINDOW_EXPIRED': 'times',
+          'CANCELED': 'times',
+      }
+      return 'fa-' + stateMap[state]
+    },
+    valueOrDefault: function(value, defaultValue) {
+      return value || defaultValue;
+    },
+    timeFromNow: function(value) {
+      return timeFromNow(value);
+    },
+    formatDate(value) {
+      return formatDate(value);
+    }
+  },
+  data: function() {
+    const stateOptions = [
+      {value: '', text: '---------'},
+      {value: 'PENDING', text: 'PENDING'},
+      {value: 'COMPLETED', text: 'COMPLETED'},
+      {value: 'WINDOW_EXPIRED', text: 'WINDOW_EXPIRED'},
+      {value: 'CANCELED', text: 'CANCELED'}
+    ]
+    const orderOptions = [
+      {value: '', text: '---------'},
+      {value: 'name', text: 'Name'},
+      {value: '-name', text: 'Name (descending)'},
+      {value: 'modified', text: 'Last Update'},
+      {value: '-modified', text: 'Last Update (descending)'},
+      {value: 'created', text: 'Created'},
+      {value: '-created', text: 'Created (descending)'},
+      {value: 'end', text: 'End of window'},
+      {value: '-end', text: 'End of window (descending)'},
+    ]
+    const defaultRgQueryParams = {
+      proposal: '',
+      order: orderOptions[0].value,
+      state: stateOptions[0].value,
+      name: '',
+      target: '',
+      created_after: '',
+      created_before: '',
+      limit: 20,
+      offset: 0
+    }
+    return {
+      orderOptions: orderOptions,
+      stateOptions: stateOptions,
+      rgQueryParams: copyObject(defaultRgQueryParams),
+      defaultRgQueryParams: defaultRgQueryParams,
+      requestgroups: { count: 0, results: [] },
+      fields: [
+        { key: 'requestgroupInfo', tdClass: 'p-0 m-0', thClass: 'border-0' },
+      ],
+      // TODO: Replace with actual profile data
+      profile: testProfileData,
+      isBusy: false,
+      errors: [],
+      currentPage: 1,
+      perPageOptions: [
+        { value: '5', text: 'Show: 5'},
+        { value: '10', text: 'Show: 10'},
+        { value: '20', text: 'Show: 20'},
+        { value: '50', text: 'Show: 50'},
+        { value: '100', text: 'Show: 100'},
+      ]
+    }
+  },
+  created: function() {
+    this.mergeRgQueryParams();
+    this.getRequestgroups();
+  },
+  computed: {
+    proposalOptions: function() {
+      let selected = this.rgQueryParams.proposal;
+      let proposalInQuery = _.get(this.$route, 'query.proposal', '');
+      let staffView = _.get(this.profile, 'profile.staff_view', false);
+      let options = [{value: '', text: '---------', selected: selected === ''}];
+      // If an admin user is checking out proposals for a proposal they don't belong to, allow filtering to work 
+      if (staffView && proposalInQuery) {
+        options.push({value: proposalInQuery, text: proposalInQuery, selected: selected === proposalInQuery});
+      }
+      if (this.profile.proposals) {
+        for (let proposal of this.profile.proposals) {
+          options.push({value: proposal.id, text: proposal.title, selected: selected === proposal.id});
+        }
+      }
+      return options;
+    }
+  },
+  methods: {
+    requestGroupRowClass: function(item, type) {
+      if (type === 'row') {
+        return stateToBsClass(item.state, 'requestgroup');
+      } else {
+        return;
+      }
+    },
+    mergeRgQueryParams: function() {
+      // Add any requestgroup query parameters that are in the url to the 
+      // request query param object so that the API request will include them.
+      for (let key in this.$route.query) {
+        if (_.has(this.rgQueryParams, key)) {
+          this.rgQueryParams[key] = this.$route.query[key];
+        }
+      }
+    },
+    calculateCurrentPage(offset) {
+      // The offset is always a multiple of the limit
+      return offset / this.rgQueryParams.limit + 1;
+    },
+    calculateOffset(currentPage) {
+      return (currentPage - 1) * this.rgQueryParams.limit;
+    },
+    getRequestgroups: function() {
+      // TODO: Take profile.staff_view and profile.view_authored_requests_only into account
+      // TODO: Cancel any currently running request
+      this.isBusy = true;
+      let url = this.observationPortalApiUrl + '/api/requestgroups/';
+      let that = this;
+      $.getJSON(url, this.rgQueryParams).done(function(data) {
+        that.requestgroups = data;
+        that.currentPage = that.calculateCurrentPage(that.rgQueryParams.offset);
+        that.errors = [];
+      }).fail(function(data) {
+        that.requestgroups = {count: 0, results: []};
+        that.currentPage = 1;
+        that.errors = [];
+        if (data.status === 400) {
+          for (let field in data.responseJSON) {
+            that.errors.push(field + ': ' + data.responseJSON[field]);
+          }
+        } else {
+          that.errors.push('There was a problem retrieving observation requests, please try again.');
+        }
+      }).always(function() {
+        that.isBusy = false;
+      })
+    },
+    onSubmit: function(event) {
+      event.preventDefault();
+      this.getRequestgroups();
+      this.$router.push({ query: this.rgQueryParams });
+    },
+    onReset: function(event) {
+      event.preventDefault();
+      this.rgQueryParams = copyObject(this.defaultRgQueryParams);
+      this.getRequestgroups();
+      this.$router.push({ query: this.rgQueryParams });
+    }
+  },
+  watch: {
+    currentPage: function(newCurrentPage) {
+      // Update the limit and offset in the params, then get a new resultset
+      if (newCurrentPage) {
+        this.rgQueryParams.offset = this.calculateOffset(newCurrentPage);
+        this.getRequestgroups();
+      }
+    },
+    'rgQueryParams.limit': function(newLimit) {
+      if (newLimit) {
+        this.getRequestgroups();
+      }
+    }
+  }
+}
+</script>
+<style scoped>
+.title {
+    font-size: 1.8em;
+}
+
+.requestgroup-details div {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+</style>

--- a/src/components/TelescopeAvailabilityChart.vue
+++ b/src/components/TelescopeAvailabilityChart.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="telescopeAvailability">
+    {{ error }}
+    <table class="availability_chart table table-bordered table-sm" v-show="sortedTelescopes.length">
+      <thead class="thead-default">
+      <th>Telescope</th>
+      <th v-for="(dateLabel, dataLabelIdx) in dateLabels" :key="dataLabelIdx">{{ dateLabel }}</th>
+      </thead>
+      <tbody class="tbody-default">
+      <tr v-for="(telescope, telescopeIdx) in sortedTelescopes" :key="telescopeIdx">
+        <td>{{ telescope | readableSiteName}}</td>
+        <td 
+          v-for="(availabilities, availabilitiesIdx) in availabilityData[telescope]" 
+          :class="[availabilityToColor(availabilities[1])]"
+          :key="availabilitiesIdx"
+        >
+          {{ (availabilities[1] * 100).toFixed() }}
+        </td>
+      </tr>
+      </tbody>
+    </table>
+    <p v-show="!sortedTelescopes.length && !error" class="text-center"><i class="fa fa-spin fa-spinner"></i></p>
+  </div>
+</template>
+<script>
+  import _ from 'lodash';
+  import $ from 'jquery';
+
+  import { siteCodeToName, observatoryCodeToNumber, telescopeCodeToName } from '@/utils.js';
+
+  export default {
+    name: 'TelescopeAvailabilityChart',
+    filters: {
+      readableSiteName: function(value) {
+        let split_string = value.split('.');
+        let site = split_string[0];
+        let observatory = split_string[1];
+        let tel = split_string[2];
+        return siteCodeToName[site] + ' ' + telescopeCodeToName[tel] + ' ' + observatoryCodeToNumber[observatory];
+      }
+    },
+    data: function(){
+      return {
+        availabilityData: {},
+        minDate:null,
+        maxDate:null,
+        dateLabels:[],
+        sortedTelescopes:[],
+        error: ''
+      };
+    },
+    created: function(){
+      let that = this;
+      let endDate = new Date();
+      let startDate = new Date(endDate);
+      startDate.setDate(startDate.getDate() - 3);
+      startDate.setHours(0);
+      startDate.setMinutes(0);
+      startDate.setSeconds(0);
+      startDate.setMilliseconds(0);
+      $.getJSON(this.observationPortalApiUrl + '/api/telescope_availability/?start=' + startDate.toISOString() + '&end=' + endDate.toISOString(),
+        function(data){
+          if(data === 'ConnectionError'){
+            that.error = 'Unable to retrieve history';
+            return;
+          }
+          that.availabilityData = data;
+        }
+      );
+    },
+    methods: {
+      availabilityToColor: function(availability){
+        if(availability > 0.75) return 'table-success';
+        else if (availability > 0.25) return 'table-warning';
+        return 'table-danger';
+      }
+    },
+    watch: {
+      availabilityData: function () {
+        this.minDate = new Date(8640000000000000);
+        this.maxDate = new Date(-8640000000000000);
+        for (let telescope in this.availabilityData){
+          if(this.availabilityData[telescope].length > 0){
+            let firstDate = new Date(this.availabilityData[telescope][0][0]);
+            if (firstDate < this.minDate){
+              this.minDate = firstDate;
+            }
+            let lastDate = new Date(_.last(this.availabilityData[telescope])[0]);
+            if (lastDate > this.maxDate){
+              this.maxDate = lastDate;
+            }
+            this.sortedTelescopes.push(telescope);
+          }
+        }
+        this.sortedTelescopes.sort();
+        this.dateLabels = [];
+        let currentDate = new Date(this.minDate);
+        while(currentDate <= this.maxDate){
+          let days_ago = Math.ceil((this.maxDate.getTime() - currentDate.getTime()) / (1000 * 3600 * 24));
+          if(days_ago === 0) this.dateLabels.push('Today');
+          else if(days_ago === 1) this.dateLabels.push('-' + days_ago + ' day');
+          else this.dateLabels.push('-' + days_ago + ' days');
+          currentDate.setDate(currentDate.getDate() + 1);
+        }
+      }
+    }
+  };
+</script>

--- a/src/components/util/DataLoadHelp.vue
+++ b/src/components/util/DataLoadHelp.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="p-0 text-secondary font-italic data-load-help">
+    <transition>
+      <span v-if="loadingDataFailed" key="loadFailed">
+        Data failed to load
+      </span>    
+      <span v-else-if="isLoading" key="loading">
+        Loading <i class="m-2 fa fa-spin fa-spinner load-spinner"></i>
+      </span>
+      <span v-else-if="!dataAvailable" key="noDataAvailable">
+        No data available for selection
+      </span>
+    </transition>
+  </div>
+</template>
+<script>
+export default {
+  name: 'DataLoadHelp',
+  props: {
+    dataAvailable: {
+      type: Boolean,
+      required: true
+    },
+    loadingDataFailed: {
+      type: Boolean,
+      required: true
+    },
+    isLoading: {
+      type: Boolean,
+      required: true
+    }
+  }
+}
+</script>
+<style scoped>
+  .data-load-help {
+    line-height: 2rem; /* Vertically center */
+  }
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -2,9 +2,13 @@ import Vue from 'vue'
 import App from './App.vue'
 import router from './router'
 import store from './store'
+import BootstrapVue from 'bootstrap-vue';
 import 'bootstrap';
-
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue/dist/bootstrap-vue.css';
 import '@/assets/css/main.css';
+
+Vue.use(BootstrapVue);
 
 Vue.config.productionTip = false
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import VueRouter from 'vue-router';
 import Home from '../views/Home.vue';
+import Tools from '../views/Tools.vue';
 import NotFound from '../views/NotFound.vue';
 import _ from 'lodash';
 
@@ -33,6 +34,18 @@ const routes = [
     component: NotFound
   },
   {
+    path: '/proposals/:id',
+    name: 'proposalsDetail',
+    // TODO: Update component
+    component: NotFound
+  },
+  {
+    path: '/requestgroups/:id',
+    name: 'requestgroupsDetail',
+    // TODO: Update component
+    component: NotFound
+  },
+  {
     path: '/accounts/profile',
     name: 'profile',
     // TODO: Update with profile component
@@ -51,6 +64,12 @@ const routes = [
     component: NotFound
   },
   {
+    path: '/register',
+    name: 'register',
+    // TODO: Update component
+    component: NotFound
+  },
+  {
     path: '/apply',
     name: 'apply',
     // TODO: Update with sciapplications component
@@ -61,6 +80,14 @@ const routes = [
     name: 'create',
     // TODO: Update with create component
     component: NotFound
+  },
+  {
+    path: '/tools',
+    name: 'tools',
+    component: Tools,
+    meta: {
+      title: 'Planning Tools'
+    }
   },
   { 
     path: '*',

--- a/src/testData.js
+++ b/src/testData.js
@@ -1,0 +1,30 @@
+// TODO: Remove this file once using actual profile data
+
+export const userIsAuthenticated = true;
+export const testProfileData = {
+    "username": "isaac newton",
+    "email": "isaac@lco.global",
+    "profile": {
+        "education_user": false,
+        "notifications_enabled": false,
+        "notifications_on_authored_only": false,
+        "simple_interface": false,
+        "view_authored_requests_only": false,
+        "staff_view": true,
+    },
+    "proposals": [
+        {
+            "id": "auto_focus",
+            "title": "LCOGT Autofocus",
+            "current": true
+        },
+        {
+            "id": "calibrate",
+            "title": "LCOGT calibrations",
+            "current": false
+        }
+    ]
+}
+
+
+export default { testProfileData, userIsAuthenticated }

--- a/src/testData.js
+++ b/src/testData.js
@@ -1,30 +1,63 @@
 // TODO: Remove this file once using actual profile data
+import { copyObject } from '@/utils.js';
 
 export const userIsAuthenticated = true;
 export const testProfileData = {
-    "username": "isaac_newton",
-    "email": "isaac@lco.global",
+    "username": "eng",
+    "email": "eng@lco.global",
     "profile": {
         "education_user": false,
         "notifications_enabled": false,
         "notifications_on_authored_only": false,
         "simple_interface": false,
         "view_authored_requests_only": false,
-        "staff_view": true,
+        "staff_view": false,
     },
     "proposals": [
         {
-            "id": "auto_focus",
-            "title": "LCOGT Autofocus",
+            "id": "current",
+            "title": "Proposal is current",
             "current": true
         },
         {
-            "id": "calibrate",
-            "title": "LCOGT calibrations",
+            "id": "non_current",
+            "title": "Proposal is not current",
             "current": false
         }
     ]
 }
 
+export function getTestProfileData(query) {
+    if (query.loggedIn === 'true') {
+        console.log('Setting logged in');
+        let data = copyObject(testProfileData);
+        if (query.authoredRequestsOnly === 'true') {
+            console.log('Setting authored requests only');
+            data.profile.view_authored_requests_only = true;
+        }
+        if (query.simpleInterface === 'true') {
+            console.log('Setting simple interface');
+            data.profile.simple_interface = true;
+        }
+        if (query.noProposals === 'true') {
+            console.log('Setting no proposals');
+            data.proposals = [];
+        }
+        if (query.noCurrentProposals === 'true') {
+            console.log('Setting no current proposals');
+            data.proposals = [
+                {
+                    "id": "non_current",
+                    "title": "Proposal is not current",
+                    "current": false
+                }
+            ]
+        }
+        return [data, true];
+    } else {
+        console.log('Not logged in');
+        return [{}, false];
+    }
+}
 
-export default { testProfileData, userIsAuthenticated }
+export default { testProfileData, userIsAuthenticated, getTestProfileData }

--- a/src/testData.js
+++ b/src/testData.js
@@ -2,7 +2,7 @@
 
 export const userIsAuthenticated = true;
 export const testProfileData = {
-    "username": "isaac newton",
+    "username": "isaac_newton",
     "email": "isaac@lco.global",
     "profile": {
         "education_user": false,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,389 @@
+import moment from 'moment';
+import _ from 'lodash';
+import $ from 'jquery';
+
+
+function isSoarInstrument(instrumentType) {
+  return _.toLower(instrumentType).includes('soar');
+}
+
+function lampFlatDefaultExposureTime(slitWidth, instrumentType, readoutMode) {
+  // Lamp flats are affected by the slit width, so exposure time needs to scale with it
+  readoutMode = _.toLower(readoutMode);
+  slitWidth = _.toLower(slitWidth);
+  if (isSoarInstrument(instrumentType)) {
+    if (readoutMode.includes('400m1')) {
+      return 3;
+    } else if (readoutMode.includes('400m2')) {
+      return 2;
+    }
+  } else {
+    if (slitWidth.includes('1.2')) {
+      return 70;
+    }
+    else if (slitWidth.includes('1.6')) {
+      return 50;
+    }
+    else if (slitWidth.includes('2.0')) {
+      return 40;
+    }
+    else if (slitWidth.includes('6.0')) {
+      return 15;
+    }
+  }
+  return 60;
+}
+
+function arcDefaultExposureTime(instrumentType) {
+  if (isSoarInstrument(instrumentType)) {
+    return 0.5;
+  } else {
+    return 60;
+  }
+}
+
+function semesterStart(datetime){
+  if(datetime.month() < 3 ){
+    return datetime.subtract(1, 'years').month(9).date(1);
+  }else if(datetime.month() < 9){
+    return datetime.month(3).date(1);
+  }else{
+    return datetime.month(9).date(1);
+  }
+}
+
+function semesterEnd(datetime){
+  if(datetime.month() < 3){
+    return datetime.month(3).date(1).subtract(1, 'days');
+  }else if(datetime.month() < 9){
+    return datetime.month(9).date(1).subtract(1, 'days');
+  }else{
+    return datetime.add(1, 'years').month(3).date(1).subtract(1, 'days');
+  }
+}
+
+function sexagesimalRaToDecimal(ra) {
+  // algorithm: ra_decimal = 15 * ( hh + mm/60 + ss/(60 * 60) )
+  /*                 (    hh     ):(     mm            ):  (   ss  ) */
+  if(typeof ra === 'string') {
+    let m = ra.match('^([0-9]?[0-9])[: ]([0-5]?[0-9][.0-9]*)[: ]?([.0-9]+)?$');
+    if (m) {
+      let hh = parseInt(m[1], 10);
+      let mm = parseFloat(m[2]);
+      let ss = m[3] ? parseFloat(m[3]) : 0.0;
+      if (hh >= 0 && hh <= 23 && mm >= 0 && mm < 60 && ss >= 0 && ss < 60) {
+        ra = (15.0 * (hh + mm / 60.0 + ss / (3600.0))).toFixed(10);
+      }
+    }
+  }
+  return ra;
+}
+
+function sexagesimalDecToDecimal(dec){
+  // algorithm: dec_decimal = sign * ( dd + mm/60 + ss/(60 * 60) )
+  /*                  ( +/-   ) (    dd     ):(     mm            ): (   ss   ) */
+  if(typeof dec === 'string') {
+    let m = dec.match('^([+-])?([0-9]?[0-9])[: ]([0-5]?[0-9][.0-9]*)[: ]?([.0-9]+)?$');
+    if (m) {
+      let sign = m[1] === '-' ? -1 : 1;
+      let dd = parseInt(m[2], 10);
+      let mm = parseFloat(m[3]);
+      let ss = m[4] ? parseFloat(m[4]) : 0.0;
+      if (dd >= 0 && dd <= 90 && mm >= 0 && mm <= 59 && ss >= 0 && ss < 60) {
+        dec = (sign * (dd + mm / 60.0 + ss / 3600.0)).toFixed(10);
+      }
+    }
+  }
+  return dec;
+}
+
+function decimalRaToSexigesimal(deg){
+  let rs = 1;
+  let ra = deg;
+  if(deg < 0){
+    rs = -1;
+    ra = Math.abs(deg);
+  }
+  let raH = Math.floor(ra / 15)
+  let raM = Math.floor(((ra / 15) - raH) * 60)
+  let raS = ((((ra / 15 ) - raH ) * 60) - raM) * 60
+  return {
+    'h': raH * rs,
+    'm': raM,
+    's': raS,
+    'str': (rs > 0 ? '' : '-') + zPadFloat(raH) + ':' + zPadFloat(raM) + ':' + zPadFloat(raS)
+  }
+}
+
+function decimalDecToSexigesimal(deg){
+  let ds = 1;
+  let dec = deg;
+  if(deg < 0){
+    ds = -1;
+    dec = Math.abs(deg);
+  }
+  let decf = Math.floor(dec)
+  let decM = Math.abs(Math.floor((dec - decf) * 60));
+  let decS = (Math.abs((dec - decf) * 60) - decM) * 60
+  return {
+    'deg': decf * ds,
+    'm': decM,
+    's': decS,
+    'str': (ds > 0 ? '' : '-') + zPadFloat(decf) + ':' + zPadFloat(decM) + ':' + zPadFloat(decS)
+  }
+}
+
+function QueryString() {
+  let qString = {};
+  let query = window.location.search.substring(1);
+  let vars = query.split('&');
+  for (let i = 0; i < vars.length; i++) {
+    let pair = vars[i].split('=');
+    if (typeof qString[pair[0]] === 'undefined') {
+      qString[pair[0]] = decodeURIComponent(pair[1]);
+    } else if (typeof qString[pair[0]] === 'string') {
+      let arr = [qString[pair[0]], decodeURIComponent(pair[1])];
+      qString[pair[0]] = arr;
+    } else {
+      qString[pair[0]].push(decodeURIComponent(pair[1]));
+    }
+  }
+  return qString;
+}
+
+ function zPadFloat(num){
+  return num.toLocaleString(undefined, {'minimumIntegerDigits': 2, 'maximumFractionDigits': 4})
+}
+
+function formatDate(date){
+  if (date) {
+    return moment.utc(String(date)).format(datetimeFormat);
+  }
+}
+
+function timeFromNow(date) {
+  if (date) {
+    return moment.utc(String(date)).fromNow()
+  } else {
+    return '';
+  }
+}
+
+function julianToModifiedJulian(jd){
+  if(jd && jd >= 2400000.5){
+    let precision = (jd + "").split(".")[1].length;
+    return Number((parseFloat(jd) - 2400000.5).toFixed(precision));
+  }
+}
+
+let apiFieldToReadable = {
+  group_id: {
+    humanReadable: 'Title',
+    description: ''
+  },
+  rotator_angle: {
+    humanReadable: 'Rotator Angle',
+    description: 'Position angle of the slit in degrees east of north.'
+  },
+  acquire_radius: {
+    humanReadable: 'Acquire Radius',
+    description: 'The radius (in arcseconds) within which to search for the brightest object.'
+  },
+  ra: {
+    humanReadable: 'RA',
+    description: ''
+  }
+};
+
+function formatField(value){
+  if (value in apiFieldToReadable) {
+    return apiFieldToReadable[value]['humanReadable'];
+  } else {
+    let words = value.split('_');
+    words = words.map(function(word){
+      return word.charAt(0).toUpperCase() + word.substr(1);
+    });
+    return words.join(' ');
+  }
+}
+
+function getFieldDescription(value) {
+  if (value in apiFieldToReadable) {
+    return apiFieldToReadable[value]['description'];
+  } else {
+    return '';
+  }
+}
+
+function formatJson(dict){
+  let stringVal = '';
+  for(let key in dict){
+    if (!_.isEmpty(dict[key]) || _.isNumber(dict[key])) {
+      if (!_.isEmpty(stringVal)) {
+        stringVal += ', ';
+      }
+      stringVal += key + ': ' + dict[key];
+    }
+  }
+  return stringVal;
+}
+
+function formatValue(value){
+  if (_.isObject(value) && !_.isArray(value)){
+    return formatJson(value);
+  }
+  else if (_.isNumber(value) && !_.isInteger(value) && !isNaN(value)){
+    return Number(value).toFixed(4);
+  }
+  return value;
+}
+
+function copyObject(source) {
+  let copy = {};
+  _.assign(copy, source);
+  return copy;
+}
+
+function extractTopLevelErrors(errors) {
+  let topLevelErrors = [];
+  if (_.isString(errors)) {
+    // The error will be a string if a validate_xxx method of the parent serializer
+    // returned an error, for example the validate_instrument_configs method on the 
+    // ConfigurationSerializer. These should be displayed at the top of a section.
+    topLevelErrors = _.concat(topLevelErrors, [errors]);
+  }
+  if (errors.non_field_errors) {
+    topLevelErrors = _.concat(topLevelErrors, errors.non_field_errors);
+  }
+  return topLevelErrors;
+}
+
+function getCookie(name) {
+  var cookieValue = null;
+  if (document.cookie && document.cookie !== '') {
+    var cookies = document.cookie.split(';');
+    for (var i = 0; i < cookies.length; i++) {
+      var cookie = $.trim(cookies[i]);
+      // Does this cookie string begin with the name we want?
+      if (cookie.substring(0, name.length + 1) === (name + '=')) {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
+      }
+    }
+  }
+  return cookieValue;
+}
+
+function csrfSafeMethod(method) {
+  // these HTTP methods do not require CSRF protection
+  return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+}
+
+function addCsrfProtection(settings, xhr) {
+  // Give ajax POSTs CSRF protection
+  if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+    var csrftoken = getCookie('csrftoken');
+    xhr.setRequestHeader('X-CSRFToken', csrftoken);
+  }
+}
+
+let datetimeFormat = 'YYYY-MM-DD HH:mm:ss';
+
+const tooltipConfig = {
+  delay: {
+    show: 500, 
+    hide: 100
+  }, 
+  trigger: 'hover'
+};
+
+let collapseMixin = {
+  watch: {
+    parentshow: function(value){
+      this.show = value;
+    }
+  }
+};
+
+function stateToBsClass(state, classPrefix) {
+  let state_map = {
+      'PENDING': 'neutral',
+      'SCHEDULED': 'info',
+      'COMPLETED': 'success',
+      'WINDOW_EXPIRED': 'danger',
+      'CANCELED': 'danger',
+  }
+  return classPrefix + '-' + state_map[state]
+}
+
+let siteToColor = {
+  'tfn': '#263c6f',  // dark blue
+  'elp': '#700000',  // dark red
+  'lsc': '#f04e23',  // red-orange
+  'cpt': '#004f00',  // dark green
+  'coj': '#fac900',  // golden-yellow
+  'ogg': '#3366dd',  // sky blue
+  'sqa': '#009d00',  // green
+  'tlv': '#8150d7',  // purple
+  'sor': '#7EF5C9',  // sea green
+  'ngq': '#FA5DEB',  // magenta
+};
+
+let siteCodeToName = {
+  'tfn': 'Teide',
+  'elp': 'McDonald',
+  'lsc': 'Cerro Tololo',
+  'cpt': 'Sutherland',
+  'coj': 'Siding Spring',
+  'ogg': 'Haleakala',
+  'sqa': 'Sedgwick',
+  'ngq': 'Ali',
+  'sor': 'Cerro Pachón',
+  'tlv': 'Wise'
+};
+
+let observatoryCodeToNumber = {
+  'doma': '1',
+  'domb': '2',
+  'domc': '3',
+  'clma': '',
+  'aqwa': '1',
+  'aqwb': '2'
+};
+
+let telescopeCodeToName = {
+  '1m0a': '1m',
+  '0m4a': '0.4m A',
+  '0m4b': '0.4m B',
+  '0m4c': '0.4m C',
+  '2m0a': '2m',
+  '4m0a': '4m',
+  '0m8a': '0.8m'
+};
+
+let colorPalette = [  // useful assigning colors to datasets.
+  '#3366CC', '#DC3912', '#FF9900', '#109618', '#990099', '#3B3EAC', '#0099C6', '#DD4477',
+  '#66AA00', '#B82E2E', '#316395', '#994499', '#22AA99', '#AAAA11', '#6633CC', '#E67300',
+  '#8B0707', '#329262', '#5574A6', '#3B3EAC', '#FFFF00', '#1CE6FF', '#FF34FF', '#FF4A46',
+  '#008941', '#006FA6', '#A30059', '#FFDBE5', '#7A4900', '#0000A6', '#63FFAC', '#B79762',
+  '#004D43', '#8FB0FF', '#997D87', '#5A0007', '#809693', '#FEFFE6', '#1B4400', '#4FC601',
+  '#61615A', '#BA0900', '#6B7900', '#00C2A0', '#FFAA92', '#FF90C9', '#B903AA', '#D16100',
+  '#DDEFFF', '#000035', '#7B4F4B', '#A1C299', '#300018', '#0AA6D8', '#013349', '#00846F',
+  '#372101', '#FFB500', '#C2FFED', '#A079BF', '#CC0744', '#C0B9B2', '#C2FF99', '#001E09',
+  '#00489C', '#6F0062', '#0CBD66', '#EEC3FF', '#456D75', '#B77B68', '#7A87A1', '#788D66',
+  '#885578', '#FAD09F', '#FF8A9A', '#D157A0', '#BEC459', '#456648', '#0086ED', '#886F4C',
+  '#34362D', '#B4A8BD', '#00A6AA', '#452C2C', '#636375', '#A3C8C9', '#FF913F', '#938A81',
+  '#575329', '#00FECF', '#B05B6F', '#8CD0FF', '#3B9700', '#04F757', '#C8A1A1', '#1E6E00',
+  '#7900D7', '#A77500', '#6367A9', '#A05837', '#6B002C', '#772600', '#D790FF', '#9B9700',
+  '#549E79', '#FFF69F', '#201625', '#72418F', '#BC23FF', '#99ADC0', '#3A2465', '#922329',
+  '#5B4534', '#FDE8DC', '#404E55', '#0089A3', '#CB7E98', '#A4E804', '#324E72', '#6A3A4C',
+  '#3B5DFF', '#4A3B53', '#FF2F80'
+];
+
+export {
+  semesterStart, semesterEnd, sexagesimalRaToDecimal, sexagesimalDecToDecimal, QueryString, formatJson, formatValue,
+  formatDate, copyObject, formatField, datetimeFormat, timeFromNow, collapseMixin, siteToColor, siteCodeToName, arcDefaultExposureTime, 
+  lampFlatDefaultExposureTime, observatoryCodeToNumber, telescopeCodeToName, colorPalette, julianToModifiedJulian, 
+  getFieldDescription, decimalRaToSexigesimal, decimalDecToSexigesimal, tooltipConfig, addCsrfProtection,
+  extractTopLevelErrors, stateToBsClass
+};

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,34 +1,102 @@
 <template>
-  <div class="home">
-    <p>Home page</p>
-    {{ requestgroups }}
-  </div>
+  <b-container class="p-0">
+    <b-row>
+      <b-col md="8" cols="12">
+        <!-- TODO: Should this section only be displayed if the table is one the first page of results? -->
+        <div v-if="!userIsAuthenticated" class="jumbotron noauth">
+            <h1>Observation Portal</h1>
+            <p>This is your access point to Las Cumbres Observatory's global network of telescopes. Registered users can:</p>
+            <ul class="list-unstyled">
+                <li><i class="fa fa-users fa-3x fa-pull-left" aria-hidden="true"></i>
+                    <span>Submit proposals and manage the membership of their research teams.</span>
+                </li>
+                <li><i class="fab fa-wpexplorer fa-3x fa-pull-left" aria-hidden="true"></i>
+                    <span>Compose, save, and submit observation requests.</span>
+                </li>
+                <li><i class="fa fa-cloud-download-alt fa-3x fa-pull-left" aria-hidden="true"></i>
+                    <span>Check the status of submitted requests, and download data from completed observations.</span>
+                </li>
+            </ul>
+            <router-link class="btn btn-lg btn-success col-md-5" :to="{name: 'register'}">Register an Account</router-link>
+            <router-link :to="{name: 'login'}" class="btn btn-lg btn-info float-right col-md-5 col-md-offset-2">Login</router-link>
+            <br/>
+        </div>
+        <requestgroups-list></requestgroups-list>
+      </b-col>
+      <b-col md="4" cols="12">
+        <b-row>
+          <b-col>
+            <h3>Quick Navigation</h3>
+            <ul class="list-unstyled sidebar-nav">
+            <li><router-link :to="{name: 'create'}"><i class="fab fa-wpexplorer fa-2x fa-fw"></i> Submit Observation</router-link></li>
+            <li><router-link :to="{name: 'proposals', query: {active: 'True'}}"><i class="fa fa-users fa-2x fa-fw"></i> Manage Proposals</router-link></li>
+            </ul>
+          </b-col>
+        </b-row>
+        <b-row>
+          <div class="col-md-12">
+            <h3>Need more information?</h3>
+            Check out the <router-link :to="{name: 'help'}">help page.</router-link>
+          </div>
+        </b-row>
+        <br>
+        <h3>Telescope availability history</h3>
+        <p>This chart shows the percent of operational science time for each telescope over the last 4 days. View the <a href="https://lco.global/observatory/status/">detailed operational status.</a></p>
+        <telescope-availability-chart></telescope-availability-chart>
+        <b-row v-if="userIsAuthenticated">
+          <b-col>
+            <h3>Active Proposals</h3>
+            <div v-for="proposal in currentProposals" :key="proposal.id">
+              <p>
+                <router-link :to="{name: 'proposalsDetail', params: {id: proposal.id}}">{{ proposal.id }}</router-link>
+                <br/>
+                <small>{{ proposal.title }}</small>
+              </p>
+            </div>
+            <div v-if="currentProposals.length < 1">
+              <!-- TODO: Translate this -->
+              <p>You have no current proposals</p>
+              <p>
+                <!-- TODO: Translate this -->
+                <router-link :to="{name: 'apply'}">Submit a proposal</router-link>
+              </p>
+            </div>
+          </b-col>
+        </b-row>
+      </b-col>
+    </b-row>
+  </b-container>
 </template>
-
 <script>
-import $ from 'jquery';
+import { testProfileData, userIsAuthenticated } from '@/testData.js';
+
+import RequestgroupsList from '@/components/RequestgroupsList.vue';
+import TelescopeAvailabilityChart from '@/components/TelescopeAvailabilityChart.vue';
 
 export default {
   name: 'Home',
+  components: {
+    RequestgroupsList,
+    TelescopeAvailabilityChart
+  },
   data: function() {
     return {
-      requestgroups: []
+      // TODO: Update to derive from actual profile data
+      profile: testProfileData,
+      userIsAuthenticated: userIsAuthenticated
     }
   },
-  mounted: function() {
-    this.getRequestgroups();
-  },
-  methods: {
-    getRequestgroups: function() {
-      let url = this.observationPortalApiUrl + "/api/requestgroups/?limit=1";
-      let that = this;
-      $.getJSON(url, function(data) {
-        that.requestgroups = data.results;
-      }).done(function() {
-        console.log('Finished loading ' + url);
-      }).fail(function() {
-        console.log('Failed to load ' + url);
-      })
+  computed: {
+    currentProposals: function() {
+      let currentProposals = [];
+      if (this.profile.proposals) {
+        for (let proposal of this.profile.proposals) {
+          if (proposal.current) {
+            currentProposals.push(proposal)
+          }
+        }
+      }
+      return currentProposals;
     }
   }
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -68,7 +68,7 @@
   </b-container>
 </template>
 <script>
-import { testProfileData, userIsAuthenticated } from '@/testData.js';
+import { getTestProfileData } from '@/testData.js';
 
 import RequestgroupsList from '@/components/RequestgroupsList.vue';
 import TelescopeAvailabilityChart from '@/components/TelescopeAvailabilityChart.vue';
@@ -80,10 +80,11 @@ export default {
     TelescopeAvailabilityChart
   },
   data: function() {
+    let testProfileData = getTestProfileData(this.$route.query);
     return {
       // TODO: Update to derive from actual profile data
-      profile: testProfileData,
-      userIsAuthenticated: userIsAuthenticated
+      profile: testProfileData[0],
+      userIsAuthenticated: testProfileData[1]
     }
   },
   computed: {

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -9,15 +9,16 @@
   </div>
 </template>
 <script>
-import { testProfileData, userIsAuthenticated } from '@/testData.js';
+import { getTestProfileData } from '@/testData.js';
 
 export default {
   name: 'NotFound',
     data: function() {
+    let testProfileData = getTestProfileData(this.$route.query);
     return {
       // TODO: Update to derive from actual profile data
-      profile: testProfileData,
-      userIsAuthenticated: userIsAuthenticated
+      profile: testProfileData[0],
+      userIsAuthenticated: testProfileData[1]
     }
   }
 }

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -4,23 +4,21 @@
       <h2>Oops! This looks like a black hole.</h2>
       <p>Either you don't have permission to view this page or it doesn't exist.</p>
       <!-- TODO: Log in link, with next query parameter to the page that was originally requestted (request.path) -->
-      <p v-if="!user.is_authenticated">Perhaps you should try <router-link :to="{name: 'login'}">logging in</router-link>.</p>
+      <p v-if="!userIsAuthenticated">Perhaps you should try <router-link :to="{name: 'login'}">logging in</router-link>.</p>
     </div>
   </div>
 </template>
 <script>
-  export default {
-    name: 'NotFound',
-      data: function() {
-      return {
-        user: {
-          username: undefined,
-          is_authenticated: false,
-          profile: {
-            simple_interface: false
-          }
-        }
-      }
+import { testProfileData, userIsAuthenticated } from '@/testData.js';
+
+export default {
+  name: 'NotFound',
+    data: function() {
+    return {
+      // TODO: Update to derive from actual profile data
+      profile: testProfileData,
+      userIsAuthenticated: userIsAuthenticated
     }
   }
+}
 </script>

--- a/src/views/Tools.vue
+++ b/src/views/Tools.vue
@@ -1,0 +1,52 @@
+<template>
+  <b-container class="my-4 mx-1">
+    <b-row>
+      <b-col>
+        <h1>Network Contention</h1>
+        <p>
+          This plot shows the amount of telescope time requested by RA and instrument.
+          Observations requested where contention is high are more likely to
+          incur scheduling conflicts.
+        </p>
+        <p>This plot excludes moving targets.</p>
+        <Contention :instruments="instruments"/>
+        <h1>Network Pressure</h1>
+        <p>
+          The pressure of a block is defined as its length divided by the total length of time during which it is visible.
+          For each time bin, this value is further divided by the number of telescopes from which the block is visible during that time bin.
+          An overall pressure of 1 (dashed line) means the network is perfectly subscribed on average (&gt; 1 is over-subscription, &lt; 1 is
+          under-subscription).
+        </p>
+        <p>This plot excludes moving targets.</p>
+        <Pressure :instruments="instruments"/>
+      </b-col>
+    </b-row>
+  </b-container>
+</template>
+<script>
+  import $ from 'jquery';
+
+  import Contention from '@/components/Contention.vue';
+  import Pressure from '@/components/Pressure.vue';
+
+  export default {
+    name: 'Tools',
+    components: {
+      Contention, 
+      Pressure
+    },
+    data: function() {
+      return {
+        instruments: []
+      }
+    },
+    created: function() {
+      let that = this;
+      $.getJSON(that.observationPortalApiUrl + '/api/instruments/', function(data) {
+        for (let instrument_type in data) {
+          that.instruments.push({value: instrument_type, text: data[instrument_type].name})
+        }
+      });
+    }
+  };
+</script>


### PR DESCRIPTION
Pulled frontend files over from the observation portal for the `/` and `/tools` pages.

The tools page was really straightforward, I didn't have to update very much in the files that I pulled over.

The main page was a bit more involved:
- For the requestgroups table, I ended up using [bootstrap vue table](https://bootstrap-vue.org/docs/components/table), which you can hook results from the API call into to generate the table, and it also has built in ways to set content that should be displayed when data is loading and when the table is empty. 
- Using the [bootstrap vue pagination](https://bootstrap-vue.org/docs/components/pagination) element to handle paginating results.
- Displaying error messages when a user requests, for example, an invalid proposal. This would happen when manually updating the query string.
- Using vue-router to make sure the query parameters in the URL update when a new API call is sent off, and that they match the filters selected in the dropdown.
- Made sure the page looks the same on mobile as the prod observation portal looks. 

Since there isn't yet a mechanism for logging in/ logging out, for the time being I just added a file (`testData.js`) where I generate some test profile data, and I read that data into the components that need it. You can control the test data that gets generated with a few query parameters. By default, there is no profile and the user is logged out. You can set the following parameters to `true` to see how the renders differently: `loggedIn`, `authoredRequestsOnly`,  `simpleInterface`, `noProposals`, `noCurrentProposals`.

The links on the pages should all work, they will just take you to the 404 page.

This branch is deployed at http://observation-portal-separate-frontend.lco.gtn/