### PR TITLE
Fix duplicate requestgroups API calls on page load

### DIFF
--- a/src/components/RequestgroupsList.vue
+++ b/src/components/RequestgroupsList.vue
@@ -463,7 +463,7 @@ export default {
       this.currentPage = 1;
       this.rgQueryParams.offset = 0;
     },
-    isIntAndChanged: function(newInt, oldInt) {
+    isNumberAndChanged: function(newInt, oldInt) {
       newInt = _.parseInt(newInt);
       oldInt = _.parseInt(oldInt);
       return _.isNumber(newInt) && newInt !== oldInt;
@@ -480,14 +480,14 @@ export default {
       this.updateRequestgroups()
     },
     onPageChange: function(newPage) {
-      if (this.isIntAndChanged(newPage, this.currentPage)) {
+      if (this.isNumberAndChanged(newPage, this.currentPage)) {
         this.currentPage = newPage;
         this.rgQueryParams.offset = this.calculateOffset(newPage);
         this.updateRequestgroups();
       }
     },
     onLimitChange: function(newLimit) {
-      if (this.isIntAndChanged(newLimit, this.rgQueryParams.limit)) {
+      if (this.isNumberAndChanged(newLimit, this.rgQueryParams.limit)) {
         this.rgQueryParams.limit = newLimit;
         this.goToFirstPage();
         this.updateRequestgroups();


### PR DESCRIPTION
The API call to get requestgroups was being triggered twice on page load, once in the created hook, and then a second time because the value of `rgQueryParams.limit` got changed from `20` to `"20"` when merging the query parameters of the page itself into the query parameters that were sent along with the API call, so the `rgQueryParams.limit` watcher sent off a second API request. 

To fix that problem, merging the page query parameters into `rgQueryParams` is now instead done in the component data initialization. I also actually ended up removing the watchers and switched to using callbacks for when a user inputs a new value into the limit dropdown or selects a new page in the pagination element. I just find that to be much easier to reason about especially since there are a few different paths by which the data that was being watched gets updated.

Finally, I added `v-if="requestgroups.count > rgQueryParams.limit"` to the pagination element as it is more in line with the current prod observation portal, where the paginate element is only displayed when there are results to be paginated.

