### PR TITLE
Feature/add observations pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -81,9 +81,9 @@
         <br />
       </div>
     </section>
-    <div class="container">
-      <div class="row">
-        <div class="col-md-12">
+    <b-container :fluid="isFluidPage">
+      <b-row>
+        <b-col md="12">
           <b-alert
             v-for="message in messages"
             :key="message.text"
@@ -94,10 +94,10 @@
           >
             {{ message.text }}
           </b-alert>
-        </div>
-      </div>
+        </b-col>
+      </b-row>
       <router-view />
-    </div>
+    </b-container>
     <div class="footer">
       Copyright © {{ year }} Las Cumbres Observatory. All rights reserved.
       <br />
@@ -135,6 +135,9 @@ export default {
     },
     messages: function() {
       return this.$store.state.messages;
+    },
+    isFluidPage: function() {
+      return this.$route.meta.isFluidPage;
     }
   },
   methods: {

--- a/src/components/ObservationHistory.vue
+++ b/src/components/ObservationHistory.vue
@@ -224,7 +224,7 @@ export default {
         // An observation on the timeline was cliked, get that observation info
         let item = that.toVis.datasets.get(event.item);
         if (item !== null) {
-          window.location.assign('/observations/' + item.observationId);
+          that.$router.push({ name: 'observationDetail', params: { id: item.observationId } });
         }
       }
     });

--- a/src/components/RequestgroupsList.vue
+++ b/src/components/RequestgroupsList.vue
@@ -151,7 +151,7 @@
         </template>
       </b-table>
       <custom-pagination
-        v-show="!isBusy"
+        v-if="!isBusy"
         table-id="requestgroups-table"
         :per-page="queryParams.limit"
         :total-rows="data.count"

--- a/src/components/RequestgroupsList.vue
+++ b/src/components/RequestgroupsList.vue
@@ -248,7 +248,7 @@ export default {
       return options;
     },
     viewAuthoredRequestsOnly: function() {
-      return this.profile.profile && this.profile.profile.view_authored_requests_only;
+      return this.profile.profile && this.profile.profile.view_authored_requests_only && !this.profile.profile.staff_view;
     }
   },
   methods: {
@@ -276,14 +276,6 @@ export default {
       } else {
         return;
       }
-    },
-    setUserIfAuthoredOnly: function() {
-      if (this.viewAuthoredRequestsOnly) {
-        this.queryParams.user = this.profile.username;
-      }
-    },
-    beforeDataUpdate: function() {
-      this.setUserIfAuthoredOnly();
     }
   }
 };

--- a/src/components/RequestgroupsList.vue
+++ b/src/components/RequestgroupsList.vue
@@ -13,46 +13,46 @@
             <b-form @submit="onSubmit" @reset="onReset">
               <b-form-group id="input-group-order" label-for="input-order" label-class="m-0" class="my-2">
                 <template v-slot:label> <i class="fa fa-sort" /> Sort </template>
-                <b-form-select id="input-order" v-model="rgQueryParams.order" :options="orderOptions" size="sm" />
+                <b-form-select id="input-order" v-model="queryParams.order" :options="orderOptions" size="sm" />
               </b-form-group>
               <b-form-group id="input-group-state" label-for="input-state" label-class="m-0" class="my-2">
                 <template v-slot:label> <i class="fas fa-sync" /> State </template>
-                <b-form-select id="input-state" v-model="rgQueryParams.state" :options="stateOptions" size="sm" />
+                <b-form-select id="input-state" v-model="queryParams.state" :options="stateOptions" size="sm" />
               </b-form-group>
               <b-form-group id="input-group-name" label-for="input-name" label-class="m-0" class="my-2">
-                <b-form-input id="input-name" v-model="rgQueryParams.name" placeholder="Name contains" size="sm" />
+                <b-form-input id="input-name" v-model="queryParams.name" placeholder="Name contains" size="sm" />
                 <template v-slot:label> <i class="fa fa-paragraph" /> Name Contains </template>
               </b-form-group>
               <b-form-group id="input-group-target" label-for="input-target" label-class="m-0" class="my-2">
-                <b-form-input id="input-target" v-model="rgQueryParams.target" placeholder="Target Name Contains" size="sm" />
+                <b-form-input id="input-target" v-model="queryParams.target" placeholder="Target Name Contains" size="sm" />
                 <template v-slot:label> <i class="fa fa-crosshairs" /> Target Name Contains </template>
               </b-form-group>
               <b-form-group id="input-group-proposal" label-for="input-proposal" label-class="m-0" class="my-2">
                 <template v-slot:label> <i class="fa fa-users" /> Proposal </template>
-                <b-form-select id="input-proposal" v-model="rgQueryParams.proposal" :options="proposalOptions" size="sm" />
+                <b-form-select id="input-proposal" v-model="queryParams.proposal" :options="proposalOptions" size="sm" />
               </b-form-group>
               <b-form-group id="input-group-created-after" label-for="input-created-after" label-class="m-0" class="my-2">
-                <b-form-input id="input-created-after" v-model="rgQueryParams.created_after" type="date" size="sm" />
+                <b-form-input id="input-created-after" v-model="queryParams.created_after" type="date" size="sm" />
                 <template v-slot:label>
                   <i class="fa fa-calendar"> <i class="fa fa-arrow-right" /> </i> Submitted After
                 </template>
               </b-form-group>
               <b-form-group id="input-group-created-before" label-for="input-created-before" label-class="m-0" class="my-2">
-                <b-form-input id="input-created-before" v-model="rgQueryParams.created_before" type="date" size="sm" />
+                <b-form-input id="input-created-before" v-model="queryParams.created_before" type="date" size="sm" />
                 <template v-slot:label> <i class="fa fa-arrow-left" /> <i class="fa fa-calendar" /> Submitted Before </template>
               </b-form-group>
               <div v-if="!viewAuthoredRequestsOnly">
                 <b-form-group id="input-group-user" label-for="input-user" label-class="m-0" class="my-2">
-                  <b-form-input id="input-user" v-model="rgQueryParams.user" placeholder="Username Contains" size="sm" />
+                  <b-form-input id="input-user" v-model="queryParams.user" placeholder="Username Contains" size="sm" />
                   <template v-slot:label> <i class="fa fa-user" /> Username Contains </template>
                 </b-form-group>
               </div>
               <b-dropdown-divider />
               <b-button-group class="mx-4">
-                <b-button type="submit" variant="outline-info">
+                <b-button type="submit" variant="outline-info" :disabled="isBusy">
                   <span class="text-nowrap">Filter Results</span>
                 </b-button>
-                <b-button type="reset" variant="outline-danger">
+                <b-button type="reset" variant="outline-danger" :disabled="isBusy">
                   <span class="text-nowrap">Clear All Fields</span>
                 </b-button>
               </b-button-group>
@@ -62,15 +62,7 @@
       </b-col>
     </b-row>
     <div>
-      <b-table
-        id="requestgroups-table"
-        :items="requestgroups.results"
-        :fields="fields"
-        :tbody-tr-class="requestGroupRowClass"
-        :busy="isBusy"
-        small
-        show-empty
-      >
+      <b-table id="requestgroups-table" :items="data.results" :fields="fields" :tbody-tr-class="requestGroupRowClass" :busy="isBusy" small show-empty>
         <template v-slot:head(requestgroupInfo)>
           <b-row>
             <b-col md="4" cols="12">
@@ -158,31 +150,25 @@
           </b-row>
         </template>
       </b-table>
-      <b-row class="row">
-        <b-col md="9" cols="12">
-          <b-pagination
-            v-if="requestgroups.count > rgQueryParams.limit"
-            :value="currentPage"
-            :total-rows="requestgroups.count"
-            :per-page="rgQueryParams.limit"
-            aria-controls="requestgroups-table"
-            @change="onPageChange"
-          />
-        </b-col>
-        <b-col md="3" cols="12">
-          <b-form-group label-for="perPageSelect">
-            <b-form-select id="perPageSelect" :value="rgQueryParams.limit" :options="perPageOptions" @change="onLimitChange" />
-          </b-form-group>
-        </b-col>
-      </b-row>
+      <custom-pagination
+        v-show="!isBusy"
+        table-id="requestgroups-table"
+        :per-page="queryParams.limit"
+        :total-rows="data.count"
+        :current-page="currentPage"
+        display-per-page-dropdown
+        @pageChange="onPageChange"
+        @limitChange="onLimitChange"
+      ></custom-pagination>
     </div>
   </b-container>
 </template>
 <script>
-import $ from 'jquery';
 import _ from 'lodash';
 
-import { timeFromNow, formatDate, copyObject, stateToBsClass, stateToIcon } from '@/utils.js';
+import { timeFromNow, formatDate, stateToBsClass, stateToIcon } from '@/utils.js';
+import { paginationAndFilteringMixin } from '@/components/util/paginationMixins.js';
+import CustomPagination from '@/components/util/CustomPagination.vue';
 
 export default {
   name: 'RequestgroupsList',
@@ -212,6 +198,10 @@ export default {
       return formatDate(value);
     }
   },
+  components: {
+    CustomPagination
+  },
+  mixins: [paginationAndFilteringMixin],
   data: function() {
     const stateOptions = [
       { value: '', text: '---------' },
@@ -231,48 +221,18 @@ export default {
       { value: 'end', text: 'End of window' },
       { value: '-end', text: 'End of window (descending)' }
     ];
-    const defaultRgQueryParams = {
-      proposal: '',
-      order: orderOptions[0].value,
-      state: stateOptions[0].value,
-      name: '',
-      target: '',
-      created_after: '',
-      created_before: '',
-      user: '',
-      limit: 20,
-      offset: 0
-    };
-    let rgQueryParams = this.getMergedRgQueryParams(defaultRgQueryParams);
-    let currentPage = this.calculateCurrentPage(rgQueryParams.offset, rgQueryParams.limit);
     return {
       orderOptions: orderOptions,
       stateOptions: stateOptions,
-      rgQueryParams: rgQueryParams,
-      defaultRgQueryParams: defaultRgQueryParams,
-      requestgroups: { count: 0, results: [] },
-      fields: [{ key: 'requestgroupInfo', tdClass: 'p-0 m-0', thClass: 'border-0' }],
-      rgQueryErrors: [],
-      isBusy: false,
-      currentPage: currentPage,
-      perPageOptions: [
-        { value: '5', text: 'Show: 5' },
-        { value: '10', text: 'Show: 10' },
-        { value: '20', text: 'Show: 20' },
-        { value: '50', text: 'Show: 50' },
-        { value: '100', text: 'Show: 100' }
-      ]
+      fields: [{ key: 'requestgroupInfo', tdClass: 'p-0 m-0', thClass: 'border-0' }]
     };
   },
   computed: {
     profile: function() {
       return this.$store.state.profile;
     },
-    observationPortalApiUrl: function() {
-      return this.$store.state.urls.observationPortalApi;
-    },
     proposalOptions: function() {
-      let selected = this.rgQueryParams.proposal;
+      let selected = this.queryParams.proposal;
       let proposalInQuery = _.get(this.$route, 'query.proposal', '');
       let staffView = _.get(this.profile, 'profile.staff_view', false);
       let options = [{ value: '', text: '---------', selected: selected === '' }];
@@ -291,10 +251,25 @@ export default {
       return this.profile.profile && this.profile.profile.view_authored_requests_only;
     }
   },
-  created: function() {
-    this.updateRequestgroups();
-  },
   methods: {
+    initializeDataEndpoint: function() {
+      return '/api/requestgroups/';
+    },
+    initializeDefaultQueryParams: function() {
+      const defaultQueryParams = {
+        proposal: '',
+        order: '',
+        state: '',
+        name: '',
+        target: '',
+        created_after: '',
+        created_before: '',
+        user: '',
+        limit: 20,
+        offset: 0
+      };
+      return defaultQueryParams;
+    },
     requestGroupRowClass: function(item, type) {
       if (type === 'row') {
         return stateToBsClass(item.state, 'requestgroup');
@@ -302,115 +277,13 @@ export default {
         return;
       }
     },
-    getMergedRgQueryParams: function(baseRgQueryParams) {
-      // Add any requestgroup query parameters that are in the url to the
-      // request query param object so that the API request will include them.
-      let mergedRgQueryParams = copyObject(baseRgQueryParams);
-      for (let key in this.$route.query) {
-        if (_.has(mergedRgQueryParams, key)) {
-          mergedRgQueryParams[key] = this.$route.query[key];
-        }
-      }
-      return mergedRgQueryParams;
-    },
-    calculateCurrentPage(offset, limit) {
-      // The offset is always a multiple of the limit
-      return offset / limit + 1;
-    },
-    calculateOffset(currentPage) {
-      return (currentPage - 1) * this.rgQueryParams.limit;
-    },
     setUserIfAuthoredOnly: function() {
       if (this.viewAuthoredRequestsOnly) {
-        this.rgQueryParams.user = this.profile.username;
+        this.queryParams.user = this.profile.username;
       }
     },
-    clearErrors: function() {
-      for (let error of this.rgQueryErrors) {
-        this.$store.commit('deleteMessage', error);
-      }
-      this.rgQueryErrors = [];
-    },
-    setErrors: function(errorsObject) {
-      for (let field in errorsObject) {
-        let message = '';
-        if (field === 'retrieving') {
-          message = errorsObject[field];
-        } else {
-          message = field + ': ' + errorsObject[field];
-        }
-        this.rgQueryErrors.push(message);
-        this.$store.commit('addMessage', { text: message, variant: 'danger' });
-      }
-    },
-    getRequestgroups: function() {
-      // TODO: Cancel any currently running request
-      this.isBusy = true;
-      let url = this.observationPortalApiUrl + '/api/requestgroups/';
-      let that = this;
-      $.getJSON(url, this.rgQueryParams)
-        .done(function(data) {
-          that.requestgroups = data;
-          that.clearErrors();
-        })
-        .fail(function(data) {
-          that.requestgroups = { count: 0, results: [] };
-          that.currentPage = 1;
-          that.clearErrors();
-          if (data.status === 400) {
-            that.setErrors(data.responseJSON);
-          } else {
-            that.setErrors({ retrieving: 'There was a problem retrieving observation requests, please try again.' });
-          }
-        })
-        .always(function() {
-          that.isBusy = false;
-        });
-    },
-    updateRequestgroups: function() {
+    beforeDataUpdate: function() {
       this.setUserIfAuthoredOnly();
-      this.getRequestgroups();
-      let newQueryParams = copyObject(this.$route.query);
-      for (let rgKey in this.rgQueryParams) {
-        newQueryParams[rgKey] = this.rgQueryParams[rgKey];
-      }
-      if (!_.isEqual(newQueryParams, this.$route.query)) {
-        this.$router.push({ query: newQueryParams });
-      }
-    },
-    goToFirstPage: function() {
-      this.currentPage = 1;
-      this.rgQueryParams.offset = 0;
-    },
-    isNumberAndChanged: function(newInt, oldInt) {
-      newInt = _.parseInt(newInt);
-      oldInt = _.parseInt(oldInt);
-      return _.isNumber(newInt) && newInt !== oldInt;
-    },
-    onSubmit: function(event) {
-      event.preventDefault();
-      this.goToFirstPage();
-      this.updateRequestgroups();
-    },
-    onReset: function(event) {
-      event.preventDefault();
-      this.rgQueryParams = copyObject(this.defaultRgQueryParams);
-      this.goToFirstPage();
-      this.updateRequestgroups();
-    },
-    onPageChange: function(newPage) {
-      if (this.isNumberAndChanged(newPage, this.currentPage)) {
-        this.currentPage = newPage;
-        this.rgQueryParams.offset = this.calculateOffset(newPage);
-        this.updateRequestgroups();
-      }
-    },
-    onLimitChange: function(newLimit) {
-      if (this.isNumberAndChanged(newLimit, this.rgQueryParams.limit)) {
-        this.rgQueryParams.limit = newLimit;
-        this.goToFirstPage();
-        this.updateRequestgroups();
-      }
     }
   }
 };

--- a/src/components/util/CustomPagination.vue
+++ b/src/components/util/CustomPagination.vue
@@ -1,0 +1,76 @@
+<template>
+  <b-row>
+    <b-col md="9" cols="12">
+      <b-pagination
+        v-if="totalRows > perPage"
+        :value="currentPage"
+        :total-rows="totalRows"
+        :per-page="perPage"
+        :aria-controls="tableId"
+        @change="onPageChange"
+      />
+    </b-col>
+    <b-col md="3" cols="12" class="text-right font-weight-bold">
+      <template v-if="displayPerPageDropdown">
+        <b-form-group label-for="perPageSelect">
+          <b-form-select id="perPageSelect" :value="perPage" :options="perPageOptions" @change="onLimitChange" />
+        </b-form-group>
+      </template>
+      <template v-else-if="!displayPerPageDropdown && totalRows > 0">
+        <div>{{ totalRows }} results</div>
+      </template>
+    </b-col>
+  </b-row>
+</template>
+<script>
+export default {
+  name: 'CustomPagination',
+  props: {
+    tableId: {
+      type: String,
+      required: true,
+      description: 'The ID of the table element to which the pagination applies'
+    },
+    perPage: {
+      validator: value => {
+        return !isNaN(value);
+      },
+      required: true
+    },
+    totalRows: {
+      validator: value => {
+        return !isNaN(value);
+      },
+      required: true
+    },
+    currentPage: {
+      validator: value => {
+        return !isNaN(value);
+      },
+      required: true
+    },
+    displayPerPageDropdown: {
+      type: Boolean
+    }
+  },
+  data: function() {
+    return {
+      perPageOptions: [
+        { value: '5', text: 'Show: 5' },
+        { value: '10', text: 'Show: 10' },
+        { value: '20', text: 'Show: 20' },
+        { value: '50', text: 'Show: 50' },
+        { value: '100', text: 'Show: 100' }
+      ]
+    };
+  },
+  methods: {
+    onPageChange: function(evt) {
+      this.$emit('pageChange', evt);
+    },
+    onLimitChange: function(evt) {
+      this.$emit('limitChange', evt);
+    }
+  }
+};
+</script>

--- a/src/components/util/paginationMixins.js
+++ b/src/components/util/paginationMixins.js
@@ -1,0 +1,212 @@
+import _ from 'lodash';
+import $ from 'jquery';
+
+import { copyObject } from '@/utils.js';
+
+export var paginationAndFilteringMixin = {
+  /* 
+  Mixin that provides basic functionality for pagination and filtering of results from an API endpoint.
+
+  Results from the endpoint are filtered using query parameters, and results are in the form
+  of `{ count: totalNumberOfResults, results: listOfAPageOfResults }`.
+  
+  The query parameter filters that are used in API requests are set in the current URL as well. This allows
+  the user to copy the query params and paste them into a separate request to the API endpoint if they wish to see
+  the exact results returned by the API.
+  
+  Query parameters that are set multiple times are represented as arrays in the `queryParams` object. For example,
+  when filtering for observations from two sites, the query string will include "site=abc&site=def", which in the
+  `queryParams` object is represented as `{ ..., site: ["abc", "def"], ... }`.
+  */
+  data: function() {
+    const dataEndpoint = this.initializeDataEndpoint();
+    const defaultQueryParams = this.initializeDefaultQueryParams();
+    let queryParams = this.getMergedQueryParams(defaultQueryParams);
+    let currentPage = this.calculateCurrentPage(queryParams.offset, queryParams.limit);
+    return {
+      // Object containing the query parameters available to filter API result
+      queryParams: queryParams,
+      defaultQueryParams: defaultQueryParams,
+      // Object containing the API results
+      data: { count: 0, results: [] },
+      errorMessages: [],
+      // Number representing which page of results are currently retrieved
+      currentPage: currentPage,
+      // Boolean that is `true` when a new set of data is being retrieved, else `false`
+      isBusy: false,
+      dataEndpoint: dataEndpoint
+    };
+  },
+  created: function() {
+    this.updateData();
+  },
+  computed: {
+    url: function() {
+      return this.$store.state.urls.observationPortalApi + this.dataEndpoint;
+    },
+    apiRequestQueryParams: function() {
+      /*
+      These are the query parameters that will be used in the request sent to the API, and are also the query
+      params that will be placed in the current URL. `apiRequestQueryParams` are a subset of `queryParams`,
+      and include only those query params that have a value. This is both because empty values, which mean no
+      filtering on that field, aren't always valid options for the request sent to the API -- filters with a
+      set of choices do not all have an empty value as a valid choice -- and because it is a lot nicer just to
+      see the filters that are used in the URL bar, rather than seeing potentially many filters with no value,
+      which makes the URL uneccessarily long.
+      */
+      let queryParams = {};
+      for (let key in this.queryParams) {
+        if (this.queryParams[key] instanceof Array) {
+          let nonEmptyValues = [];
+          for (let value of this.queryParams[key]) {
+            if (value) nonEmptyValues.push(value);
+          }
+          if (nonEmptyValues.length > 0) {
+            queryParams[key] = nonEmptyValues;
+          }
+        } else {
+          if (this.queryParams[key]) {
+            queryParams[key] = this.queryParams[key];
+          }
+        }
+      }
+      return queryParams;
+    }
+  },
+  methods: {
+    initializeDataEndpoint: function() {
+      // Override this method to initialize the endpoint from which data will be retrieved.
+      return '';
+    },
+    initializeDefaultQueryParams: function() {
+      // Override this method to initialize the default query parameters. The default query params
+      // should be a `const`, and must include `limit` and `offset` as fields.
+      const defaultQueryParams = {
+        limit: 10,
+        offset: 0
+      };
+      return defaultQueryParams;
+    },
+    getMergedQueryParams: function(baseQueryParams) {
+      // Add any query parameters that are in the url that are used in the API call to `queryParams`
+      // so that the request sent to the API will include them.
+      let mergedQueryParams = copyObject(baseQueryParams);
+      for (let key in this.$route.query) {
+        if (_.has(mergedQueryParams, key)) {
+          if (mergedQueryParams[key] instanceof Array) {
+            if (this.$route.query[key] instanceof Array) {
+              mergedQueryParams[key] = this.$route.query[key];
+            } else {
+              mergedQueryParams[key] = [this.$route.query[key]];
+            }
+          } else {
+            mergedQueryParams[key] = this.$route.query[key];
+          }
+        }
+      }
+      return mergedQueryParams;
+    },
+    clearErrors: function() {
+      for (let message of this.errorMessages) {
+        this.$store.commit('deleteMessage', message);
+      }
+      this.messages = [];
+    },
+    setErrors: function(errorMessagesObject) {
+      for (let field in errorMessagesObject) {
+        let message = '';
+        if (field === 'retrieving') {
+          message = errorMessagesObject[field];
+        } else {
+          message = field + ': ' + errorMessagesObject[field];
+        }
+        this.errorMessages.push(message);
+        this.$store.commit('addMessage', { text: message, variant: 'danger' });
+      }
+    },
+    getData: function() {
+      this.isBusy = true;
+      let that = this;
+      $.ajax({
+        url: this.url,
+        data: this.apiRequestQueryParams,
+        traditional: true
+      })
+        .done(function(data) {
+          that.data = data;
+          that.clearErrors();
+        })
+        .fail(function(data) {
+          that.data = { count: 0, results: [] };
+          that.currentPage = 1;
+          that.clearErrors();
+          if (data.status === 400) {
+            that.setErrors(data.responseJSON);
+          } else {
+            that.setErrors({ retrieving: 'There was a problem retrieving your data, please try again.' });
+          }
+        })
+        .always(function() {
+          that.isBusy = false;
+        });
+    },
+    beforeDataUpdate: function() {
+      // Override this method in the component to include other actions that must be run
+      // before a new set of data is retrieved.
+      return;
+    },
+    updateData: function() {
+      this.beforeDataUpdate();
+      this.getData();
+      if (this.$route.fullPath !== this.$router.resolve({ query: this.apiRequestQueryParams }).href) {
+        this.$router.push({ query: this.apiRequestQueryParams });
+      }
+    },
+    calculateCurrentPage: function(offset, limit) {
+      // The offset is always a multiple of the limit
+      return offset / limit + 1;
+    },
+    calculateOffset: function(currentPage) {
+      return (currentPage - 1) * this.queryParams.limit;
+    },
+    goToFirstPage: function() {
+      this.currentPage = 1;
+      this.queryParams.offset = 0;
+    },
+    isNumberAndChanged: function(newInt, oldInt) {
+      newInt = _.parseInt(newInt);
+      oldInt = _.parseInt(oldInt);
+      return _.isNumber(newInt) && newInt !== oldInt;
+    },
+    onSubmit: function(event) {
+      // Call this method to get a new set of results when new query parameters
+      // have been set.
+      event.preventDefault();
+      this.goToFirstPage();
+      this.updateData();
+    },
+    onReset: function(event) {
+      // Call this method to reset the query parameters to their default values.
+      event.preventDefault();
+      this.queryParams = copyObject(this.defaultQueryParams);
+      this.goToFirstPage();
+      this.updateData();
+    },
+    onPageChange: function(newPage) {
+      // Call this method to get a new page of results.
+      if (this.isNumberAndChanged(newPage, this.currentPage)) {
+        this.currentPage = newPage;
+        this.queryParams.offset = this.calculateOffset(newPage);
+        this.updateData();
+      }
+    },
+    onLimitChange: function(newLimit) {
+      // Call this method to update the total number of results per page.
+      if (this.isNumberAndChanged(newLimit, this.queryParams.limit)) {
+        this.queryParams.limit = newLimit;
+        this.goToFirstPage();
+        this.updateData();
+      }
+    }
+  }
+};

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -10,6 +10,7 @@ import AccountsGet from '../views/AccountsGet.vue';
 import AccountsForm from '../views/AccountsForm.vue';
 import AccountRemovalRequest from '../views/AccountRemovalRequest.vue';
 import RequestgroupDetail from '../views/RequestgroupDetail.vue';
+import Observations from '../views/Observations.vue';
 import ObservationDetail from '../views/ObservationDetail.vue';
 import Compose from '../views/Compose.vue';
 import NotFound from '../components/NotFound.vue';
@@ -69,9 +70,10 @@ const routes = [
   {
     path: '/observations',
     name: 'observations',
-    component: NotFound,
+    component: Observations,
     meta: {
-      title: 'Observations'
+      title: 'Observations',
+      isFluidPage: true
     }
   },
   {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -10,6 +10,7 @@ import AccountsGet from '../views/AccountsGet.vue';
 import AccountsForm from '../views/AccountsForm.vue';
 import AccountRemovalRequest from '../views/AccountRemovalRequest.vue';
 import RequestgroupDetail from '../views/RequestgroupDetail.vue';
+import ObservationDetail from '../views/ObservationDetail.vue';
 import Compose from '../views/Compose.vue';
 import NotFound from '../components/NotFound.vue';
 import store from '../store/index.js';
@@ -63,6 +64,22 @@ const routes = [
     component: RequestgroupDetail,
     meta: {
       title: 'Request Detail'
+    }
+  },
+  {
+    path: '/observations',
+    name: 'observations',
+    component: NotFound,
+    meta: {
+      title: 'Observations'
+    }
+  },
+  {
+    path: '/observations/:id',
+    name: 'observationDetail',
+    component: ObservationDetail,
+    meta: {
+      title: 'Observation Detail'
     }
   },
   {

--- a/src/views/Compose.vue
+++ b/src/views/Compose.vue
@@ -243,8 +243,7 @@ export default {
           data: JSON.stringify(that.requestgroup),
           contentType: 'application/json',
           success: function(data) {
-            // TODO: Use the router
-            window.location = '/requestgroups/' + data.id;
+            that.$router.push({ name: 'requestgroupDetail', params: { id: data.id } });
           }
         });
       }

--- a/src/views/ObservationDetail.vue
+++ b/src/views/ObservationDetail.vue
@@ -1,0 +1,159 @@
+<template>
+  <div class="row">
+    <div class="col-md-12">
+      <template v-if="observationLoadError">
+        <p class="text-center my-2">
+          Oops, there was a problem getting your data, please try again
+        </p>
+      </template>
+      <template v-else-if="!dataLoaded">
+        <div class="text-center my-2">
+          <i class="fa fa-spin fa-spinner" />
+        </div>
+      </template>
+      <template v-else-if="dataLoaded && !observation.site">
+        {{ observation.id }}
+        <not-found />
+      </template>
+      <template v-else>
+        <h1>Observation {{ id }}</h1>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Request</th>
+              <th>Site</th>
+              <th>Enclosure</th>
+              <th>Telescope</th>
+              <th>Start</th>
+              <th>End</th>
+              <th>State</th>
+              <th>Priority</th>
+              <th>Modified</th>
+              <th>Created</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <router-link :to="{ name: 'requestDetail', params: { id: observation.request } }">
+                  {{ observation.request }}
+                </router-link>
+              </td>
+              <td>{{ observation.site }}</td>
+              <td>{{ observation.enclosure }}</td>
+              <td>{{ observation.telescope }}</td>
+              <td>{{ observation.start | formatDate }}</td>
+              <td>{{ observation.end | formatDate }}</td>
+              <td>{{ observation.state }}</td>
+              <td>{{ observation.priority }}</td>
+              <td>{{ observation.modified | formatDate }}</td>
+              <td>{{ observation.created | formatDate }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th colspan="4" style="border-right: 2px solid black">Config Status</th>
+              <th colspan="6">Summary</th>
+            </tr>
+            <tr>
+              <th>Id</th>
+              <th>Instrument</th>
+              <th>Guider</th>
+              <th style="border-right: 2px solid black">State</th>
+              <th>State</th>
+              <th>Start</th>
+              <th>End</th>
+              <th>Reason</th>
+              <th>Time</th>
+              <th>Events</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="c_status in observation.configuration_statuses" :key="c_status.id">
+              <td>{{ c_status.id }}</td>
+              <td>{{ c_status.instrument_name }}</td>
+              <td>{{ c_status.guide_camera_name }}</td>
+              <td style="border-right: 2px solid black">{{ c_status.state }}</td>
+              <template v-if="c_status.summary">
+                <td>{{ c_status.summary.state }}</td>
+                <td>{{ c_status.summary.start | formatDate }}</td>
+                <td>{{ c_status.summary.end | formatDate }}</td>
+                <td>{{ c_status.summary.reason }}</td>
+                <td>{{ c_status.summary.time_completed }}</td>
+                <td><a href="#" @click="openEvents(c_status.summary.events)">View</a></td>
+              </template>
+              <template v-else>
+                <td colspan="6">No summary</td>
+              </template>
+            </tr>
+          </tbody>
+        </table>
+      </template>
+    </div>
+  </div>
+</template>
+<script>
+import $ from 'jquery';
+
+import NotFound from '@/components/NotFound.vue';
+import { formatDate } from '@/utils.js';
+
+export default {
+  name: 'ObservationDetail',
+  components: {
+    NotFound
+  },
+  filters: {
+    formatDate(value) {
+      return formatDate(value);
+    }
+  },
+  data: function() {
+    return {
+      id: this.$route.params.id,
+      observation: {},
+      observationLoadError: false,
+      dataLoaded: false
+    };
+  },
+  computed: {
+    observationPortalApiUrl: function() {
+      return this.$store.state.urls.observationPortalApi;
+    }
+  },
+  created: function() {
+    this.getObservation();
+  },
+  methods: {
+    getObservation: function() {
+      let that = this;
+      $.ajax({
+        url: this.observationPortalApiUrl + '/api/observations/' + this.id
+      })
+        .done(function(response) {
+          that.observation = response;
+        })
+        .fail(function(response) {
+          if (response.status !== 404) {
+            that.observationLoadError = true;
+          }
+        })
+        .always(function() {
+          that.dataLoaded = true;
+        });
+    },
+    openEvents: function(events_text) {
+      var y = window.top.outerHeight / 2 + window.top.screenY - 300;
+      var x = window.top.outerWidth / 2 + window.top.screenX - 300;
+      var newWin = open(
+        '',
+        'Events',
+        'scrollbars=yes, toolbar=no, location=no, menubar=no, width=' + 600 + ', height=' + 600 + ', top=' + y + ', left=' + x
+      );
+      newWin.document.write('<pre>' + JSON.stringify(events_text, null, 2) + '</pre>');
+    }
+  }
+};
+</script>

--- a/src/views/ObservationDetail.vue
+++ b/src/views/ObservationDetail.vue
@@ -12,7 +12,6 @@
         </div>
       </template>
       <template v-else-if="dataLoaded && !observation.site">
-        {{ observation.id }}
         <not-found />
       </template>
       <template v-else>

--- a/src/views/Observations.vue
+++ b/src/views/Observations.vue
@@ -1,27 +1,18 @@
 <template>
   <b-row class="p-3">
     <b-col cols="10" md="10">
-      <b-row>
-        <b-col md="9" cols="12">
-          <b-pagination
-            v-if="!isBusy && observations.count > observationsQueryParams.limit"
-            :value="currentPage"
-            :total-rows="observations.count"
-            :per-page="observationsQueryParams.limit"
-            aria-controls="observations-table"
-            @change="onPageChange"
-          />
-        </b-col>
-        <b-col md="3" cols="12" class="text-right font-weight-bold">
-          <template v-if="!isBusy && observations.count > 0">
-            <div>{{ observations.count }} observations</div>
-          </template>
-        </b-col>
-      </b-row>
+      <custom-pagination
+        v-show="!isBusy"
+        table-id="observations-table"
+        :per-page="queryParams.limit"
+        :total-rows="data.count"
+        :current-page="currentPage"
+        @pageChange="onPageChange"
+      ></custom-pagination>
       <b-row>
         <b-table
           id="observations-table"
-          :items="observations.results"
+          :items="data.results"
           :fields="fields"
           :tbody-tr-class="observationGroupRowClass"
           :busy="isBusy"
@@ -67,23 +58,14 @@
           </template>
         </b-table>
       </b-row>
-      <b-row>
-        <b-col md="9" cols="12">
-          <b-pagination
-            v-if="!isBusy && observations.count > observationsQueryParams.limit"
-            :value="currentPage"
-            :total-rows="observations.count"
-            :per-page="observationsQueryParams.limit"
-            aria-controls="observations-table"
-            @change="onPageChange"
-          />
-        </b-col>
-        <b-col md="3" cols="12" class="text-right font-weight-bold">
-          <template v-if="!isBusy && observations.count > 0">
-            <div>{{ observations.count }} observations</div>
-          </template>
-        </b-col>
-      </b-row>
+      <custom-pagination
+        v-show="!isBusy"
+        table-id="observations-table"
+        :per-page="queryParams.limit"
+        :total-rows="data.count"
+        :current-page="currentPage"
+        @pageChange="onPageChange"
+      ></custom-pagination>
     </b-col>
     <b-col cols="2" md="2">
       <template v-if="filtersLoaded">
@@ -97,56 +79,42 @@
             </b-button>
           </b-button-group>
           <b-form-group id="input-group-site" label="Site" label-for="input-site">
-            <b-form-select id="input-site" v-model="observationsQueryParams.site" :options="formattedFilterOptions.site" multiple></b-form-select>
+            <b-form-select id="input-site" v-model="queryParams.site" :options="formattedFilterOptions.site" multiple></b-form-select>
           </b-form-group>
           <b-form-group id="input-group-enclosure" label="Enclosure" label-for="input-enclosure">
-            <b-form-select
-              id="input-enclosure"
-              v-model="observationsQueryParams.enclosure"
-              :options="formattedFilterOptions.enclosure"
-              multiple
-            ></b-form-select>
+            <b-form-select id="input-enclosure" v-model="queryParams.enclosure" :options="formattedFilterOptions.enclosure" multiple></b-form-select>
           </b-form-group>
           <b-form-group id="input-group-telescope" label="Telescope" label-for="input-telescope">
-            <b-form-select
-              id="input-telescope"
-              v-model="observationsQueryParams.telescope"
-              :options="formattedFilterOptions.telescope"
-              multiple
-            ></b-form-select>
+            <b-form-select id="input-telescope" v-model="queryParams.telescope" :options="formattedFilterOptions.telescope" multiple></b-form-select>
           </b-form-group>
           <b-form-group id="input-group-priority" label="Priority" label-for="input-priority">
-            <b-form-input id="input-priority" v-model="observationsQueryParams.priority" type="number"></b-form-input>
+            <b-form-input id="input-priority" v-model="queryParams.priority" type="number"></b-form-input>
           </b-form-group>
           <b-form-group id="input-group-state" label="State" label-for="input-state">
-            <b-form-select id="input-state" v-model="observationsQueryParams.state" :options="formattedFilterOptions.state" multiple></b-form-select>
+            <b-form-select id="input-state" v-model="queryParams.state" :options="formattedFilterOptions.state" multiple></b-form-select>
           </b-form-group>
           <b-form-group id="input-group-time-span" label="Time Span" label-for="input-time-span">
-            <b-form-select
-              id="input-time-span"
-              v-model="observationsQueryParams.time_span"
-              :options="formattedFilterOptions.time_span"
-            ></b-form-select>
+            <b-form-select id="input-time-span" v-model="queryParams.time_span" :options="formattedFilterOptions.time_span"></b-form-select>
           </b-form-group>
           <b-form-group id="input-group-start-after" label="Start After (Inclusive)" label-for="input-start-after">
-            <b-form-input id="input-start-after" v-model="observationsQueryParams.start_after" type="date"></b-form-input>
+            <b-form-input id="input-start-after" v-model="queryParams.start_after" type="date"></b-form-input>
           </b-form-group>
           <b-form-group id="input-group-start-before" label="Start Before" label-for="input-start-before">
-            <b-form-input id="input-start-before" v-model="observationsQueryParams.start_before" type="date"></b-form-input>
+            <b-form-input id="input-start-before" v-model="queryParams.start_before" type="date"></b-form-input>
           </b-form-group>
           <b-form-group id="input-group-modified-after" label="Modified After (Inclusive)" label-for="input-modified-after">
-            <b-form-input id="input-modified-after" v-model="observationsQueryParams.modified_after" type="date"></b-form-input>
+            <b-form-input id="input-modified-after" v-model="queryParams.modified_after" type="date"></b-form-input>
           </b-form-group>
           <b-form-group id="input-group-request-id" label="Request ID" label-for="input-request-id">
-            <b-form-input id="input-request-id" v-model="observationsQueryParams.request_id" type="number"></b-form-input>
+            <b-form-input id="input-request-id" v-model="queryParams.request_id" type="number"></b-form-input>
           </b-form-group>
           <b-form-group id="input-group-request-group-id" label="Request Group ID" label-for="input-request-group-id">
-            <b-form-input id="input-request-group-id" v-model="observationsQueryParams.request_group_id" type="number"></b-form-input>
+            <b-form-input id="input-request-group-id" v-model="queryParams.request_group_id" type="number"></b-form-input>
           </b-form-group>
           <b-form-group id="input-group-observation-type" label="Observation Type" label-for="input-observation-type">
             <b-form-select
               id="input-observation-type"
-              v-model="observationsQueryParams.observation_type"
+              v-model="queryParams.observation_type"
               :options="formattedFilterOptions.observation_type"
               multiple
             ></b-form-select>
@@ -154,18 +122,18 @@
           <b-form-group id="input-group-request-state" label="Request State" label-for="input-request-state">
             <b-form-select
               id="input-request-state"
-              v-model="observationsQueryParams.request_state"
+              v-model="queryParams.request_state"
               :options="formattedFilterOptions.request_state"
               multiple
             ></b-form-select>
           </b-form-group>
           <b-form-group id="input-group-proposal" label="Proposal" label-for="input-proposal">
-            <b-form-input id="input-proposal" v-model="observationsQueryParams.proposal" type="text"></b-form-input>
+            <b-form-input id="input-proposal" v-model="queryParams.proposal" type="text"></b-form-input>
           </b-form-group>
           <b-form-group id="input-group-instrument-type" label="Instrument Type" label-for="input-instrument-type">
             <b-form-select
               id="input-instrument-type"
-              v-model="observationsQueryParams.instrument_type"
+              v-model="queryParams.instrument_type"
               :options="formattedFilterOptions.instrument_type"
               multiple
             ></b-form-select>
@@ -173,13 +141,13 @@
           <b-form-group id="input-group-configuration-type" label="Configuration Type" label-for="input-configuration-type">
             <b-form-select
               id="input-configuration-type"
-              v-model="observationsQueryParams.configuration_type"
+              v-model="queryParams.configuration_type"
               :options="formattedFilterOptions.configuration_type"
               multiple
             ></b-form-select>
           </b-form-group>
           <b-form-group id="input-group-ordering" label="Ordering" label-for="input-ordering">
-            <b-form-select id="input-ordering" v-model="observationsQueryParams.ordering" :options="formattedFilterOptions.ordering"></b-form-select>
+            <b-form-select id="input-ordering" v-model="queryParams.ordering" :options="formattedFilterOptions.ordering"></b-form-select>
           </b-form-group>
           <b-button-group>
             <b-button type="submit" variant="outline-info" :disabled="isBusy">
@@ -201,44 +169,24 @@
 </template>
 <script>
 import $ from 'jquery';
-import _ from 'lodash';
 
-import { formatDate, copyObject } from '@/utils.js';
+import { formatDate } from '@/utils.js';
+import { paginationAndFilteringMixin } from '@/components/util/paginationMixins.js';
+import CustomPagination from '@/components/util/CustomPagination.vue';
 
 export default {
   name: 'ObservationsList',
+  components: {
+    CustomPagination
+  },
   filters: {
     formatDate(value) {
       return formatDate(value);
     }
   },
+  mixins: [paginationAndFilteringMixin],
   data: function() {
-    const defaultObservationsQueryParams = {
-      site: [],
-      enclosure: [],
-      telescope: [],
-      state: ['COMPLETED', 'PENDING', 'IN_PROGRESS', 'ABORTED', 'FAILED'],
-      time_span: '',
-      observation_type: [],
-      request_state: [],
-      instrument_type: [],
-      configuration_type: [],
-      ordering: '',
-      start_after: '',
-      start_before: '',
-      modified_after: '',
-      request_id: '',
-      request_group_id: '',
-      priority: '',
-      limit: 5,
-      offset: 0
-    };
-    let observationsQueryParams = this.getMergedObservationQueryParams(defaultObservationsQueryParams);
-    let currentPage = this.calculateCurrentPage(observationsQueryParams.offset, observationsQueryParams.limit);
     return {
-      observationsQueryParams: observationsQueryParams,
-      defaultObservationsQueryParams: defaultObservationsQueryParams,
-      observations: { count: 0, results: [] },
       fields: [
         { key: 'id' },
         'site',
@@ -252,9 +200,6 @@ export default {
         { key: 'modified' },
         { key: 'created' }
       ],
-      observationsQueryErrors: [],
-      isBusy: false,
-      currentPage: currentPage,
       filtersLoaded: false,
       filterOptions: { fields: [], choice_fields: [] }
     };
@@ -262,31 +207,6 @@ export default {
   computed: {
     observationPortalApiUrl: function() {
       return this.$store.state.urls.observationPortalApi;
-    },
-    apiRequestQueryParams: function() {
-      // These are the query parameters that will be used in the request sent to the API,
-      // and are also the params that will be placed in the current url. These are used in
-      // the current url because 1) it is nicer to see only the active filters in the url bar
-      // instead of seeing a bunch of empty query params, and 2) so that the url can be replaced
-      // with /api/ between the domain and the rest of the url, and you'll be able to see the
-      // same exact results from the api.
-      let queryParams = {};
-      for (let key in this.observationsQueryParams) {
-        if (this.observationsQueryParams[key] instanceof Array) {
-          let nonEmptyValues = [];
-          for (let value of this.observationsQueryParams[key]) {
-            if (value) nonEmptyValues.push(value);
-          }
-          if (nonEmptyValues.length > 0) {
-            queryParams[key] = nonEmptyValues;
-          }
-        } else {
-          if (this.observationsQueryParams[key]) {
-            queryParams[key] = this.observationsQueryParams[key];
-          }
-        }
-      }
-      return queryParams;
     },
     formattedFilterOptions: function() {
       let options = {};
@@ -301,9 +221,34 @@ export default {
   },
   created: function() {
     this.getFilterOptions();
-    this.updateObservations();
   },
   methods: {
+    initializeDataEndpoint: function() {
+      return '/api/observations/';
+    },
+    initializeDefaultQueryParams: function() {
+      const defaultQueryParams = {
+        site: [],
+        enclosure: [],
+        telescope: [],
+        state: ['COMPLETED', 'PENDING', 'IN_PROGRESS', 'ABORTED', 'FAILED'],
+        time_span: '',
+        observation_type: [],
+        request_state: [],
+        instrument_type: [],
+        configuration_type: [],
+        ordering: '',
+        start_after: '',
+        start_before: '',
+        modified_after: '',
+        request_id: '',
+        request_group_id: '',
+        priority: '',
+        limit: 50,
+        offset: 0
+      };
+      return defaultQueryParams;
+    },
     parseInstrumentsInObservation: function(observation) {
       let instruments = [];
       if (observation.request) {
@@ -332,50 +277,6 @@ export default {
         }
       }
     },
-    getMergedObservationQueryParams: function(baseObservationsQueryParams) {
-      // Add any observation query parameters that are in the url to the
-      // observation query param object so that the API request will include them.
-      let mergedObservationsQueryParams = copyObject(baseObservationsQueryParams);
-      for (let key in this.$route.query) {
-        if (_.has(mergedObservationsQueryParams, key)) {
-          if (mergedObservationsQueryParams[key] instanceof Array) {
-            if (this.$route.query[key] instanceof Array) {
-              mergedObservationsQueryParams[key] = this.$route.query[key];
-            } else {
-              mergedObservationsQueryParams[key] = [this.$route.query[key]];
-            }
-          } else {
-            mergedObservationsQueryParams[key] = this.$route.query[key];
-          }
-        }
-      }
-      return mergedObservationsQueryParams;
-    },
-    calculateCurrentPage(offset, limit) {
-      // The offset is always a multiple of the limit
-      return offset / limit + 1;
-    },
-    calculateOffset(currentPage) {
-      return (currentPage - 1) * this.observationsQueryParams.limit;
-    },
-    clearErrors: function() {
-      for (let error of this.observationsQueryErrors) {
-        this.$store.commit('deleteMessage', error);
-      }
-      this.observationsQueryErrors = [];
-    },
-    setErrors: function(errorsObject) {
-      for (let field in errorsObject) {
-        let message = '';
-        if (field === 'retrieving') {
-          message = errorsObject[field];
-        } else {
-          message = field + ': ' + errorsObject[field];
-        }
-        this.observationsQueryErrors.push(message);
-        this.$store.commit('addMessage', { text: message, variant: 'danger' });
-      }
-    },
     getFilterOptions: function() {
       let that = this;
       $.ajax({
@@ -384,65 +285,6 @@ export default {
         that.filterOptions = response;
         that.filtersLoaded = true;
       });
-    },
-    getObservations: function() {
-      this.isBusy = true;
-      let that = this;
-      $.ajax({
-        url: this.observationPortalApiUrl + '/api/observations/',
-        data: this.apiRequestQueryParams,
-        traditional: true
-      })
-        .done(function(data) {
-          that.observations = data;
-          that.clearErrors();
-        })
-        .fail(function(data) {
-          that.observations = { count: 0, results: [] };
-          that.currentPage = 1;
-          that.clearErrors();
-          if (data.status === 400) {
-            that.setErrors(data.responseJSON);
-          } else {
-            that.setErrors({ retrieving: 'There was a problem retrieving observations, please try again.' });
-          }
-        })
-        .always(function() {
-          that.isBusy = false;
-        });
-    },
-    updateObservations: function() {
-      this.getObservations();
-      if (this.$route.fullPath !== this.$router.resolve({ query: this.apiRequestQueryParams }).href) {
-        this.$router.push({ query: this.apiRequestQueryParams });
-      }
-    },
-    goToFirstPage: function() {
-      this.currentPage = 1;
-      this.observationsQueryParams.offset = 0;
-    },
-    isNumberAndChanged: function(newInt, oldInt) {
-      newInt = _.parseInt(newInt);
-      oldInt = _.parseInt(oldInt);
-      return _.isNumber(newInt) && newInt !== oldInt;
-    },
-    onSubmit: function(event) {
-      event.preventDefault();
-      this.goToFirstPage();
-      this.updateObservations();
-    },
-    onReset: function(event) {
-      event.preventDefault();
-      this.observationsQueryParams = copyObject(this.defaultObservationsQueryParams);
-      this.goToFirstPage();
-      this.updateObservations();
-    },
-    onPageChange: function(newPage) {
-      if (this.isNumberAndChanged(newPage, this.currentPage)) {
-        this.currentPage = newPage;
-        this.observationsQueryParams.offset = this.calculateOffset(newPage);
-        this.updateObservations();
-      }
     }
   }
 };

--- a/src/views/Observations.vue
+++ b/src/views/Observations.vue
@@ -2,7 +2,7 @@
   <b-row class="p-3">
     <b-col cols="10" md="10">
       <custom-pagination
-        v-show="!isBusy"
+        v-if="!isBusy"
         table-id="observations-table"
         :per-page="queryParams.limit"
         :total-rows="data.count"
@@ -59,7 +59,7 @@
         </b-table>
       </b-row>
       <custom-pagination
-        v-show="!isBusy"
+        v-if="!isBusy"
         table-id="observations-table"
         :per-page="queryParams.limit"
         :total-rows="data.count"

--- a/src/views/Observations.vue
+++ b/src/views/Observations.vue
@@ -1,0 +1,307 @@
+<template>
+  <b-row class="p-3">
+    <b-col cols="10" md="10">
+      <b-row>
+        <b-col md="9" cols="12">
+          <b-pagination
+            v-if="observations.count > observationsQueryParams.limit"
+            :value="currentPage"
+            :total-rows="observations.count"
+            :per-page="observationsQueryParams.limit"
+            aria-controls="observations-table"
+            @change="onPageChange"
+          />
+        </b-col>
+        <b-col md="3" cols="12">
+          <template v-if="lastUpdated">
+            <div>{{ observationsCount }} observations</div>
+            <div>
+              Last update: <span class="font-weight-bold">{{ lastUpdated | formatDate }}</span>
+            </div>
+          </template>
+        </b-col>
+      </b-row>
+      <b-row>
+        <b-table
+          id="observations-table"
+          :items="observations.results"
+          :fields="fields"
+          :tbody-tr-class="observationGroupRowClass"
+          :busy="isBusy"
+          small
+          show-empty
+          responsive
+        >
+          <template v-slot:table-busy>
+            <br />
+            <div class="text-center my-2"><i class="fa fa-spin fa-spinner" /> Loading observations...</div>
+            <br />
+          </template>
+          <template v-slot:empty>
+            <!-- TODO: Check the style -->
+            <div>
+              <center>
+                <h2>No observations found.</h2>
+              </center>
+            </div>
+          </template>
+          <template v-slot:cell(id)="data">
+            <router-link :to="{ name: 'observationDetail', params: { id: data.item.id } }">{{ data.item.id }}</router-link>
+          </template>
+          <template v-slot:cell(start)="data">
+            <span>{{ data.value | formatDate }}</span>
+          </template>
+          <template v-slot:cell(end)="data">
+            <span>{{ data.value | formatDate }}</span>
+          </template>
+          <template v-slot:cell(modified)="data">
+            <span>{{ data.value | formatDate }}</span>
+          </template>
+          <template v-slot:cell(created)="data">
+            <span>{{ data.value | formatDate }}</span>
+          </template>
+          <template v-slot:cell(requestId)="data">
+            <router-link :to="{ name: 'requestDetail', params: { id: data.item.request.id } }">{{ data.item.request.id }}</router-link>
+          </template>
+          <template v-slot:cell(instruments)="data">
+            <span v-for="instrument in getObservationInstruments(data.item)" :key="instrument">{{ instrument }}</span
+            ><br />
+          </template>
+        </b-table>
+      </b-row>
+      <b-row>
+        <b-col md="9" cols="12">
+          <b-pagination
+            v-if="observations.count > observationsQueryParams.limit"
+            :value="currentPage"
+            :total-rows="observations.count"
+            :per-page="observationsQueryParams.limit"
+            aria-controls="observations-table"
+            @change="onPageChange"
+          />
+        </b-col>
+        <b-col md="3" cols="12">
+          <template v-if="lastUpdated">
+            <div>{{ observationsCount }} observations</div>
+            <div>
+              Last update: <span class="font-weight-bold">{{ lastUpdated | formatDate }}</span>
+            </div>
+          </template>
+        </b-col>
+      </b-row>
+    </b-col>
+    <b-col cols="2" md="2">
+      <b-form @submit="onSubmit" @reset="onReset">
+        <!-- TODO: Add filters -->
+        <b-button-group>
+          <b-button type="submit" variant="outline-info">
+            <span>Filter</span>
+          </b-button>
+          <b-button type="reset" variant="outline-danger">
+            <span>Reset</span>
+          </b-button>
+        </b-button-group>
+      </b-form>
+    </b-col>
+  </b-row>
+</template>
+<script>
+import $ from 'jquery';
+import _ from 'lodash';
+
+import { formatDate, copyObject } from '@/utils.js';
+
+export default {
+  name: 'ObservationsList',
+  filters: {
+    formatDate(value) {
+      return formatDate(value);
+    }
+  },
+  data: function() {
+    const defaultObservationsQueryParams = {
+      limit: 5,
+      offset: 0
+    };
+    let observationsQueryParams = this.getMergedObservationQueryParams(defaultObservationsQueryParams);
+    let currentPage = this.calculateCurrentPage(observationsQueryParams.offset, observationsQueryParams.limit);
+    return {
+      observationsQueryParams: observationsQueryParams,
+      defaultObservationsQueryParams: defaultObservationsQueryParams,
+      observations: { count: 0, results: [] },
+      fields: [
+        { key: 'id' },
+        'site',
+        { key: 'enclosure', label: 'Enc.' },
+        { key: 'telescope', label: 'Tel.' },
+        { key: 'start' },
+        { key: 'end' },
+        { key: 'requestId', label: 'Req.ID' },
+        'proposal',
+        'instruments',
+        { key: 'modified' },
+        { key: 'created' }
+      ],
+      observationsQueryErrors: [],
+      isBusy: false,
+      currentPage: currentPage
+    };
+  },
+  computed: {
+    observationPortalApiUrl: function() {
+      return this.$store.state.urls.observationPortalApi;
+    },
+    observationsCount: function() {
+      return this.observations.count || 0;
+    },
+    lastUpdated: function() {
+      // TODO: Fix this. This maintains the current behavior, but this is only actually correct
+      // if the selected ordering is "-modified".
+      if (this.observations.results.length > 0) {
+        return this.observations.results[0].modified;
+      } else {
+        return null;
+      }
+    },
+    apiRequestQueryParams: function() {
+      let queryParams = {};
+      for (let key in this.observationsQueryParams) {
+        if (this.observationsQueryParams[key]) {
+          queryParams[key] = this.observationsQueryParams[key];
+        }
+      }
+      return queryParams;
+    }
+  },
+  created: function() {
+    this.updateObservations();
+  },
+  methods: {
+    getObservationInstruments: function(observation) {
+      let instruments = [];
+      if (observation.request) {
+        for (let configuration of observation.request.configurations) {
+          if (instruments.indexOf(configuration.instrument_type) === -1) {
+            instruments.push(configuration.instrument_type);
+          }
+        }
+      }
+      return instruments;
+    },
+    observationGroupRowClass: function(item, type) {
+      if (!item || type !== 'row') {
+        return;
+      } else {
+        if (item.state === 'COMPLETED') {
+          return 'table-success';
+        } else if (item.state === 'CANCELED') {
+          return 'table-secondary';
+        } else if (item.state === 'FAILED' || item.state === 'ABORTED') {
+          return 'table-danger';
+        } else if (item.state === 'IN_PROGRESS') {
+          return 'table-warning';
+        } else {
+          return 'table-default';
+        }
+      }
+    },
+    getMergedObservationQueryParams: function(baseObservationsQueryParams) {
+      // Add any observation query parameters that are in the url to the
+      // observation query param object so that the API request will include them.
+      let mergedObservationsQueryParams = copyObject(baseObservationsQueryParams);
+      for (let key in this.$route.query) {
+        if (_.has(mergedObservationsQueryParams, key)) {
+          mergedObservationsQueryParams[key] = this.$route.query[key];
+        }
+      }
+      return mergedObservationsQueryParams;
+    },
+    calculateCurrentPage(offset, limit) {
+      // The offset is always a multiple of the limit
+      return offset / limit + 1;
+    },
+    calculateOffset(currentPage) {
+      return (currentPage - 1) * this.observationsQueryParams.limit;
+    },
+    clearErrors: function() {
+      for (let error of this.observationsQueryErrors) {
+        this.$store.commit('deleteMessage', error);
+      }
+      this.observationsQueryErrors = [];
+    },
+    setErrors: function(errorsObject) {
+      for (let field in errorsObject) {
+        let message = '';
+        if (field === 'retrieving') {
+          message = errorsObject[field];
+        } else {
+          message = field + ': ' + errorsObject[field];
+        }
+        this.observationsQueryErrors.push(message);
+        this.$store.commit('addMessage', { text: message, variant: 'danger' });
+      }
+    },
+    getObservations: function() {
+      // TODO: Cancel any currently running request
+      this.isBusy = true;
+      let url = this.observationPortalApiUrl + '/api/observations/';
+      let that = this;
+      $.getJSON(url, this.apiRequestQueryParams)
+        .done(function(data) {
+          that.observations = data;
+          that.clearErrors();
+        })
+        .fail(function(data) {
+          that.observations = { count: 0, results: [] };
+          that.currentPage = 1;
+          that.clearErrors();
+          if (data.status === 400) {
+            that.setErrors(data.responseJSON);
+          } else {
+            that.setErrors({ retrieving: 'There was a problem retrieving observations, please try again.' });
+          }
+        })
+        .always(function() {
+          that.isBusy = false;
+        });
+    },
+    updateObservations: function() {
+      this.getObservations();
+      let newQueryParams = copyObject(this.$route.query);
+      for (let obsKey in this.apiRequestQueryParams) {
+        newQueryParams[obsKey] = this.apiRequestQueryParams[obsKey];
+      }
+      if (!_.isEqual(newQueryParams, this.$route.query)) {
+        this.$router.push({ query: newQueryParams });
+      }
+    },
+    goToFirstPage: function() {
+      this.currentPage = 1;
+      this.observationsQueryParams.offset = 0;
+    },
+    isNumberAndChanged: function(newInt, oldInt) {
+      newInt = _.parseInt(newInt);
+      oldInt = _.parseInt(oldInt);
+      return _.isNumber(newInt) && newInt !== oldInt;
+    },
+    onSubmit: function(event) {
+      event.preventDefault();
+      this.goToFirstPage();
+      this.updateObservations();
+    },
+    onReset: function(event) {
+      event.preventDefault();
+      this.observationsQueryParams = copyObject(this.defaultObservationsQueryParams);
+      this.goToFirstPage();
+      this.updateObservations();
+    },
+    onPageChange: function(newPage) {
+      if (this.isNumberAndChanged(newPage, this.currentPage)) {
+        this.currentPage = newPage;
+        this.observationsQueryParams.offset = this.calculateOffset(newPage);
+        this.updateObservations();
+      }
+    }
+  }
+};
+</script>

--- a/src/views/Observations.vue
+++ b/src/views/Observations.vue
@@ -237,7 +237,7 @@ export default {
         request_state: [],
         instrument_type: [],
         configuration_type: [],
-        ordering: '',
+        ordering: '-start',
         start_after: '',
         start_before: '',
         modified_after: '',

--- a/src/views/RequestgroupDetail.vue
+++ b/src/views/RequestgroupDetail.vue
@@ -86,7 +86,7 @@ export default {
       requestgroupLoadError: false,
       fields: [{ key: 'requestRow', tdClass: 'p-0' }],
       currentPage: 1,
-      perPage: 10
+      perPage: 25
     };
   },
   computed: {


### PR DESCRIPTION
Added `/observations` and `/observations/:observationId`

There are a couple of obs portal pages that are fluid, meaning they should take up the entire width of the page. The observations page is one of those pages. I added a meta field to the route definition that marks if a page is fluid, which is then used in the template to determine the container type.

The new views are in `src/views/Observations.vue` and `src/views/ObservationDetail.vue`. There was a lot of overlap between `src/views/Observations.vue` and `src/components/RequestgroupsList.vue`, which is the component that is displayed on the home page the filters/paginations requestgroups. Parts of these two components which are common for filtering and pagination I moved into `src/components/util/paginationMixins.js`. There are quite a few changes you'll see in `src/components/RequestgroupsList.vue`, which are all pretty much just switching over to use the mixin. I also made a custom pagination component since a pagination component is displayed multiple times, but they end up having to look about the same.

As usual, this branch is running at http://observation-portal-separate-frontend.lco.gtn/