### PR TITLE
Fix/integration testing fixes

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,4 @@
 > 1%
 last 2 versions
 not dead
+ie >= 10

--- a/src/App.vue
+++ b/src/App.vue
@@ -74,7 +74,7 @@
         </b-collapse>
       </b-navbar>
     </div>
-    <b-container :fluid="isFluidPage" class="flex-shrink-0">
+    <b-container :fluid="isFluidPage" class="flex-shrink-0 p-0">
       <b-row>
         <b-col md="12">
           <b-alert

--- a/src/components/EditSciApplication.vue
+++ b/src/components/EditSciApplication.vue
@@ -363,6 +363,7 @@
               <template v-if="pdfPath">
                 Currently: <b-link :href="pdfPath">{{ pdfBaseName }}</b-link>
                 <b-form-checkbox v-model="clearPdf" class="d-inline ml-1">Clear</b-form-checkbox>
+                <b-alert v-for="error in apiValidationErrors.clear_pdf" :key="error" variant="danger" dismissible show> {{ error }}</b-alert>
                 <div class="pt-2">Change:</div>
               </template>
               <basic-custom-field v-model="sciApp.pdf" field-type="file" :errors="pdfErrors" label="Upload PDF" accept=".pdf, .PDF" label-sr-only>
@@ -500,7 +501,12 @@ export default {
       return lastElementWithoutQueryString || this.pdfPath;
     },
     pdfErrors: function() {
-      let errors = this.apiValidationErrors.pdf || [];
+      let errors = [];
+      if (this.apiValidationErrors.pdf) {
+        for (let pdfApiValidationError of this.apiValidationErrors.pdf) {
+          errors.push(pdfApiValidationError);
+        }
+      }
       if (this.pdfIsTooLarge) {
         errors.push('PDF is too large');
       }

--- a/src/components/EditSciApplication.vue
+++ b/src/components/EditSciApplication.vue
@@ -361,7 +361,7 @@
                 </template>
               </div>
               <template v-if="pdfPath">
-                Currently: <b-link :href="pdfPath">{{ pdfBaseName }}</b-link>
+                Currently: <b-link :href="pdfPath" target="_blank">{{ pdfBaseName }}</b-link>
                 <b-form-checkbox v-model="clearPdf" class="d-inline ml-1">Clear</b-form-checkbox>
                 <b-alert v-for="error in apiValidationErrors.clear_pdf" :key="error" variant="danger" dismissible show> {{ error }}</b-alert>
                 <div class="pt-2">Change:</div>
@@ -599,7 +599,7 @@ export default {
       }
     },
     addCoInvestigator: function() {
-      this.sciApp.coinvestigator_set.push(copyObject(this.emptyCoInvestigator));
+      this.sciApp.coinvestigator_set.push(copyObject(this.getEmptyCoInvestigator()));
     },
     removeTimeRequest: function(index) {
       if (index >= 0) {
@@ -607,7 +607,7 @@ export default {
       }
     },
     addTimeRequest: function() {
-      this.sciApp.timerequest_set.push(copyObject(this.emptyTimeRequest));
+      this.sciApp.timerequest_set.push(copyObject(this.getEmptyTimeRequest()));
     },
     sendApplication(data) {
       let method = 'POST';

--- a/src/components/EditSciApplication.vue
+++ b/src/components/EditSciApplication.vue
@@ -22,7 +22,7 @@
         </template>
         <p>{{ data.eligibility }}</p>
         <b-alert v-for="error in apiValidationErrors.non_field_errors" :key="error" variant="danger" dismissible show> {{ error }}</b-alert>
-        <b-alert v-for="error in apiValidationErrors.call" :key="error" variant="danger" dismissible show> {{ error }}</b-alert>
+        <b-alert v-for="error in apiValidationErrors.call_id" :key="error" variant="danger" dismissible show> {{ error }}</b-alert>
         <b-form>
           <basic-custom-field v-model="sciApp.title" :errors="apiValidationErrors.title" label="Title" placeholder="Title"></basic-custom-field>
           <basic-custom-field
@@ -496,7 +496,8 @@ export default {
     },
     pdfBaseName: function() {
       let lastElementofPath = _.last(_.split(this.pdfPath, '/'));
-      return lastElementofPath || this.pdfPath;
+      let lastElementWithoutQueryString = _.head(_.split(lastElementofPath, '?'));
+      return lastElementWithoutQueryString || this.pdfPath;
     },
     pdfErrors: function() {
       let errors = this.apiValidationErrors.pdf || [];

--- a/src/components/SciApplicationDetailTemplate.vue
+++ b/src/components/SciApplicationDetailTemplate.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="sciapp-detail-content">
     <ul v-if="!isCombinedPdf" style="float:right;">
-      <li><a href="#" @click="goBack()">Back</a></li>
+      <li><b-link href="#" @click="goBack()">Back</b-link></li>
       <li><b-link href="#" @click="printPage()">Print this page</b-link></li>
       <li><router-link :to="{ name: 'appCombinedPdf', params: { sciAppId: sciApp.id } }" target="_blank">View Pdf</router-link></li>
     </ul>

--- a/src/components/SciApplicationDetailTemplate.vue
+++ b/src/components/SciApplicationDetailTemplate.vue
@@ -3,7 +3,7 @@
     <ul v-if="!isCombinedPdf" style="float:right;">
       <li><a href="#" @click="goBack()">Back</a></li>
       <li><b-link href="#" @click="printPage()">Print this page</b-link></li>
-      <li><router-link :to="{ name: 'appCombinedPdf', params: { sciAppId: sciApp.id } }">View Pdf</router-link></li>
+      <li><router-link :to="{ name: 'appCombinedPdf', params: { sciAppId: sciApp.id } }" target="_blank">View Pdf</router-link></li>
     </ul>
     <template v-if="sciApp.title">
       <h1>{{ sciApp.title }}</h1>
@@ -84,7 +84,7 @@
     </template>
     <template v-if="sciApp.pdf && !isCombinedPdf">
       <h2>Uploaded PDF</h2>
-      <p><a :href="sciApp.pdf">Download</a></p>
+      <p><a :href="sciApp.pdf" target="_blank">Download</a></p>
     </template>
     <!-- eslint-disable -->
     <component :is="'style'">

--- a/src/components/SciApplications.vue
+++ b/src/components/SciApplications.vue
@@ -36,7 +36,7 @@
         <router-link :to="{ name: 'appDetail', params: { sciAppId: data.item.id } }" class="px-1">
           <span class="text-primary mx-auto"><i class="fa fa-print"></i></span>
         </router-link>
-        <router-link :to="{ name: 'appCombinedPdf', params: { sciAppId: data.item.id } }" class="px-1">
+        <router-link :to="{ name: 'appCombinedPdf', params: { sciAppId: data.item.id } }" class="px-1" target="_blank">
           <span class="text-primary mx-auto"><i class="far fa-file-pdf"></i></span>
         </router-link>
       </template>
@@ -84,7 +84,7 @@
         <router-link :to="{ name: 'appDetail', params: { sciAppId: data.item.id } }">
           <span class="text-primary mx-auto"><i class="fa fa-print"></i></span>
         </router-link>
-        <router-link :to="{ name: 'appCombinedPdf', params: { sciAppId: data.item.id } }">
+        <router-link :to="{ name: 'appCombinedPdf', params: { sciAppId: data.item.id } }" target="_blank">
           <span class="text-primary mx-auto"><i class="far fa-file-pdf"></i></span>
         </router-link>
       </template>

--- a/src/main.js
+++ b/src/main.js
@@ -60,4 +60,4 @@ $.ajax({
       // TODO: Display error page
       console.log('Error getting profile data');
     });
-})
+});

--- a/src/main.js
+++ b/src/main.js
@@ -12,12 +12,10 @@ Vue.use(BootstrapVue);
 
 Vue.config.productionTip = false;
 
-const getRuntimeConfig = async () => {
-  const runtimeConfig = await fetch('/config/urls.json');
-  return await runtimeConfig.json();
-};
-
-getRuntimeConfig().then(function(json) {
+$.ajax({
+  method: 'GET',
+  url: '/config/urls.json'
+}).done(function(json) {
   store.commit('setRuntimeConfig', {
     observationPortalApi: process.env.VUE_APP_OBSERVATION_PORTAL_API_URL || json.observationPortalApiUrl,
     archiveApi: process.env.VUE_APP_ARCHIVE_API_URL || json.archiveApiUrl,
@@ -62,4 +60,4 @@ getRuntimeConfig().then(function(json) {
       // TODO: Display error page
       console.log('Error getting profile data');
     });
-});
+})

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -201,7 +201,8 @@ const routes = [
     name: 'profile',
     component: Profile,
     meta: {
-      title: 'Profile'
+      title: 'Profile',
+      requiresAuth: true
     }
   },
   {

--- a/src/views/Apply.vue
+++ b/src/views/Apply.vue
@@ -5,7 +5,7 @@
       <b-table :items="nonCollabCalls" :fields="nonCollabCallsFields" :busy="!dataLoaded" show-empty>
         <template #empty>
           <div v-if="dataLoadError" class="text-center text-muted my-2">Oops, there was a problem getting your data. Please try again.</div>
-          <h4 v-else>No active calls at this time</h4>
+          <div v-else class="text-center text-muted my-2">No active calls at this time.</div>
         </template>
         <template #table-busy>
           <div class="text-center my-2"><i class="fa fa-spin fa-spinner" /> Loading...</div>

--- a/src/views/Help.vue
+++ b/src/views/Help.vue
@@ -62,10 +62,10 @@
         best-effort basis.
       </p>
       <ul class="list-unstyled">
-        <li>Google Chrome/Chromium: <strong>56+</strong></li>
-        <li>Mozilla Firefox: <strong>46+</strong></li>
+        <li>Google Chrome/Chromium: <strong>67+</strong></li>
+        <li>Mozilla Firefox: <strong>78+</strong></li>
         <li>Apple Safari: <strong>11.1+</strong></li>
-        <li>Microsoft Edge: <strong>17+</strong></li>
+        <li>Microsoft Edge: <strong>80+</strong></li>
         <li>Internet Explorer: <strong>10+</strong> (minimal support)</li>
       </ul>
       <p>

--- a/src/views/SciApplicationCombinedPdf.vue
+++ b/src/views/SciApplicationCombinedPdf.vue
@@ -1,6 +1,6 @@
 <template>
   <data-loader :data-loaded="dataLoaded" :data-load-error="dataLoadError" :data-not-found="dataNotFound">
-    <embed id="combined-pdf" style="position:absolute; left: 0; top: 0;" width="100%" height="100%" type="application/pdf" />
+    <iframe id="combined-pdf" style="position:absolute; left: 0; top: 0; border: none;" width="100%" height="100%" type="application/pdf" />
     <b-embed type="iframe" height="0" width="0" style="border: none;">
       <sci-application-detail-template id="pdf-content" :sci-app="data" is-combined-pdf></sci-application-detail-template>
     </b-embed>

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,10 +1,7 @@
 const path = require('path');
 
 module.exports = {
-  transpileDependencies: [
-    'pdf-lib',
-    'html2pdf.js'
-  ],
+  transpileDependencies: ['pdf-lib', 'html2pdf.js'],
   chainWebpack: config => {
     config.plugin('html').tap(args => {
       args[0].title = 'LCO Observation Portal';

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,10 @@
 const path = require('path');
 
 module.exports = {
+  transpileDependencies: [
+    'pdf-lib',
+    'html2pdf.js'
+  ],
   chainWebpack: config => {
     config.plugin('html').tap(args => {
       args[0].title = 'LCO Observation Portal';


### PR DESCRIPTION
A bunch of minor fixes from a round of integration testing:
- Update some styling.
- Update the list of supported browsers. The way that I chose versions for browsers other than IE, was I looked through the browsers on the different operating systems available on browserstack, chose a sufficiently old OS, and took the latest version of that browser available on that OS. Of course this doesn't mean that the app won't work on older versions that what is stated, just that these are the tested versions where everything should work.
- Fix some cross-browser issues:
    - Transpile the pdf libraries so that they work on older browsers.
    - Switch from using the `<embed>` tag to using an `<iframe>` when displaying the combined pdf object blob url. The former did not work on Safari, and only worked on more recent versions of Firefox.
 - `fetch` had been used to get the app configuration in `main.js`, but everywhere else in the app uses jquery for ajax calls, so I switched that one usage of `fetch` to use jquery as well. 
- Fix new time request or co-investigator rows added to the sciapp form so that the initial data is populated correctly.
- Open links to PDFs in a new tab.
- Update the text of the link to the uploaded PDF that is displayed to the user on the sciapp form page so that only the base name of the filename is displayed, without the query string attached.