### PR TITLE
Update jitter help text

### DIFF
--- a/src/components/Window.vue
+++ b/src/components/Window.vue
@@ -78,7 +78,7 @@
               v-model="jitter"
               label="Jitter"
               field="jitter"
-              desc="Acceptable deviation from strict period (before or after) in decimal hours."
+              desc="Acceptable deviation from strict period (before or after) in decimal hours. Must be long enough to contain one observation request, including overheads."
               :errors="errors.jitter"
               @input="update"
             />


### PR DESCRIPTION
Add more information to the jitter help text.

<img width="381" alt="jitter_help" src="https://user-images.githubusercontent.com/8227676/104667728-9c709980-568b-11eb-88d4-9e3c1970a52b.png">
