### PR TITLE
Add proposal code to filter dropdown

### DIFF
--- a/src/components/RequestgroupsList.vue
+++ b/src/components/RequestgroupsList.vue
@@ -243,7 +243,8 @@ export default {
       }
       if (this.profile.proposals) {
         for (let proposal of this.profile.proposals) {
-          options.push({ value: proposal.id, text: proposal.title, selected: selected === proposal.id });
+          let proposalText = `${proposal.title} (${proposal.id})`;
+          options.push({ value: proposal.id, text: proposalText, selected: selected === proposal.id });
         }
       }
       return options;

--- a/src/components/RequestgroupsList.vue
+++ b/src/components/RequestgroupsList.vue
@@ -243,7 +243,7 @@ export default {
       }
       if (this.profile.proposals) {
         for (let proposal of this.profile.proposals) {
-          let proposalText = `${proposal.title} (${proposal.id})`;
+          let proposalText = `${proposal.id}: ${proposal.title}`;
           options.push({ value: proposal.id, text: proposalText, selected: selected === proposal.id });
         }
       }


### PR DESCRIPTION
Ref. [issue 1393](https://lcoglobal.redmineup.com/issues/1393)

Tim noted that he was not able to distinguish his proposals by name and the inclusion of the code would help matters.

The Python developer in me opted to use a [template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to construct the dropdown text, but I am totally open to better alternatives.

![image](https://user-images.githubusercontent.com/7182533/109094737-561d4a00-76cf-11eb-99a6-cebf53967475.png)

I've deployed this change to the dev frontend at http://observation-portal-dev.lco.gtn 