### PR TITLE
Update to ocs-component-lib 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "jquery-file-download": "^1.4.6",
         "lodash": "^4.17.13",
         "moment": "^2.22.1",
-        "ocs-component-lib": "^0.4.0",
+        "ocs-component-lib": "^0.6.0",
         "pdf-lib": "^1.12.0",
         "popper.js": "^1.16.1",
         "vis": "4.19.1",
@@ -11959,9 +11959,9 @@
       "dev": true
     },
     "node_modules/ocs-component-lib": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/ocs-component-lib/-/ocs-component-lib-0.4.0.tgz",
-      "integrity": "sha512-9A15c4CmYGLBx9hMBuuGsZZqwBT9t3d28L26fC9nTRhwaX/ZoMcqV05J61CgEtkezQJJobd+m5QCBagP3PbBlQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ocs-component-lib/-/ocs-component-lib-0.6.0.tgz",
+      "integrity": "sha512-L8PkoFyUlbm1wWhXlDzpKnWBmZulWkYJvz8camZ2dVPz5jPBmRqGS18Rqxs5dPukJ/fIS9wst4vLr8Vo4InjUA==",
       "dependencies": {
         "core-js": "^3.6.5",
         "vue": "^2.6.11"
@@ -27798,9 +27798,9 @@
       "dev": true
     },
     "ocs-component-lib": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/ocs-component-lib/-/ocs-component-lib-0.4.0.tgz",
-      "integrity": "sha512-9A15c4CmYGLBx9hMBuuGsZZqwBT9t3d28L26fC9nTRhwaX/ZoMcqV05J61CgEtkezQJJobd+m5QCBagP3PbBlQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ocs-component-lib/-/ocs-component-lib-0.6.0.tgz",
+      "integrity": "sha512-L8PkoFyUlbm1wWhXlDzpKnWBmZulWkYJvz8camZ2dVPz5jPBmRqGS18Rqxs5dPukJ/fIS9wst4vLr8Vo4InjUA==",
       "requires": {
         "core-js": "^3.6.5",
         "vue": "^2.6.11"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jquery-file-download": "^1.4.6",
     "lodash": "^4.17.13",
     "moment": "^2.22.1",
-    "ocs-component-lib": "^0.4.0",
+    "ocs-component-lib": "^0.6.0",
     "pdf-lib": "^1.12.0",
     "popper.js": "^1.16.1",
     "vis": "4.19.1",


### PR DESCRIPTION
This updates the observation-portal-frontend to use the updated RequestGroups List component, which contains additional filtering options.

This branch is currently deployed at http://observation-portal-dev.lco.gtn

lco-observation-portal PR: https://github.com/LCOGT/observation-portal-project/pull/4