### PR TITLE
Fix simple interface muscat submission

### DIFF
--- a/src/components/InstrumentConfig.vue
+++ b/src/components/InstrumentConfig.vue
@@ -115,7 +115,7 @@
             />
             <div v-for="opticalElementGroup in availableOpticalElementGroups" :key="opticalElementGroup.type">
               <custom-select
-                v-if="!simpleInterface || (simpleInterface && selectedinstrument !== '2M0-SCICAM-MUSCAT')"
+                v-if="!(simpleInterface && selectedinstrument == '2M0-SCICAM-MUSCAT')"
                 v-model="instrumentconfig.optical_elements[opticalElementGroup.type]"
                 :label="opticalElementGroup.label"
                 :field="opticalElementGroup.type"
@@ -281,23 +281,15 @@ export default {
         if (this.selectedinstrument === '2M0-SCICAM-MUSCAT') {
           return {
             diffuser_g_position: {
-              type: 'diffuser_g_position',
-              label: 'Diffuser g position',
               options: [{ value: 'out', text: 'Out of Beam', default: true }]
             },
             diffuser_r_position: {
-              type: 'diffuser_r_position',
-              label: 'Diffuser r position',
               options: [{ value: 'out', text: 'Out of Beam', default: true }]
             },
             diffuser_i_position: {
-              type: 'diffuser_i_position',
-              label: 'Diffuser i position',
               options: [{ value: 'out', text: 'Out of Beam', default: true }]
             },
             diffuser_z_position: {
-              type: 'diffuser_z_position',
-              label: 'Diffuser z position',
               options: [{ value: 'out', text: 'Out of Beam', default: true }]
             }
           };

--- a/src/components/InstrumentConfig.vue
+++ b/src/components/InstrumentConfig.vue
@@ -115,6 +115,7 @@
             />
             <div v-for="opticalElementGroup in availableOpticalElementGroups" :key="opticalElementGroup.type">
               <custom-select
+                v-if="!simpleInterface || (simpleInterface && selectedinstrument !== '2M0-SCICAM-MUSCAT')"
                 v-model="instrumentconfig.optical_elements[opticalElementGroup.type]"
                 :label="opticalElementGroup.label"
                 :field="opticalElementGroup.type"
@@ -277,17 +278,42 @@ export default {
     },
     availableOpticalElementGroups: function() {
       if (this.simpleInterface) {
-        return {
-          filters: {
-            type: 'filter',
-            label: 'Filter',
-            options: [
-              { value: 'b', text: 'Blue' },
-              { value: 'v', text: 'Green' },
-              { value: 'rp', text: 'Red' }
-            ]
-          }
-        };
+        if (this.selectedinstrument === '2M0-SCICAM-MUSCAT') {
+          return {
+            diffuser_g_position: {
+              type: 'diffuser_g_position',
+              label: 'Diffuser g position',
+              options: [{ value: 'out', text: 'Out of Beam', default: true }]
+            },
+            diffuser_r_position: {
+              type: 'diffuser_r_position',
+              label: 'Diffuser r position',
+              options: [{ value: 'out', text: 'Out of Beam', default: true }]
+            },
+            diffuser_i_position: {
+              type: 'diffuser_i_position',
+              label: 'Diffuser i position',
+              options: [{ value: 'out', text: 'Out of Beam', default: true }]
+            },
+            diffuser_z_position: {
+              type: 'diffuser_z_position',
+              label: 'Diffuser z position',
+              options: [{ value: 'out', text: 'Out of Beam', default: true }]
+            }
+          };
+        } else {
+          return {
+            filter: {
+              type: 'filter',
+              label: 'Filter',
+              options: [
+                { value: 'b', text: 'Blue', default: true },
+                { value: 'v', text: 'Green', default: false },
+                { value: 'rp', text: 'Red', default: false }
+              ]
+            }
+          };
+        }
       } else if (this.selectedinstrument in this.availableInstruments) {
         let oe_groups = {};
         for (let oe_group_type in this.availableInstruments[this.selectedinstrument].optical_elements) {
@@ -396,14 +422,10 @@ export default {
     availableOpticalElementGroups: function(value) {
       // TODO: Implement optical element history
       this.instrumentconfig.optical_elements = {};
-      if (this.simpleInterface) {
-        this.instrumentconfig.optical_elements.filter = 'b';
-      } else {
-        for (let oe_type in value) {
-          for (let oe_value_idx in value[oe_type]['options']) {
-            if (value[oe_type]['options'][oe_value_idx].default) {
-              this.instrumentconfig.optical_elements[oe_type] = value[oe_type]['options'][oe_value_idx].value;
-            }
+      for (let oe_type in value) {
+        for (let oe_value_idx in value[oe_type]['options']) {
+          if (value[oe_type]['options'][oe_value_idx].default) {
+            this.instrumentconfig.optical_elements[oe_type] = value[oe_type]['options'][oe_value_idx].value;
           }
         }
       }


### PR DESCRIPTION
Fixes https://lcoglobal.redmineup.com/issues/1428

Simple interface submission was never updated to work for muscat. This PR sets the optical elements available for muscat submission when the a client is using the simple interface. The optical elements are hard coded like this for the simple interface since the clients are not supposed to be able to see all the options to keep it simple.

Ultimately this fix will be superseded when this project is updated to use the compose page component from the component lib, but I did it like this here anyway to get the fix out there.