### PR TITLE
Fix/proposal invitations

### DIFF
--- a/src/components/EditSciApplication.vue
+++ b/src/components/EditSciApplication.vue
@@ -236,7 +236,8 @@
               <div class="help-block">
                 <template v-if="data.proposal_type === 'SCI'">
                   <p>
-                    For the remainder of your proposal, please upload a single pdf file that includes the following sections but <em>not</em> an author list:
+                    For the remainder of your proposal, please upload a single pdf file that includes the following sections but <em>not</em> an
+                    author list:
                   </p>
                   <ul>
                     <li>
@@ -255,7 +256,8 @@
                       identify them.
                     </li>
                     <li>
-                      <strong>Report of related programs on other telescopes.</strong> A concise account of other programs that relate to this proposal.
+                      <strong>Report of related programs on other telescopes.</strong> A concise account of other programs that relate to this
+                      proposal.
                     </li>
                     <li>
                       <strong>Report on use of LCO in the past 3 years.</strong> A concise account of LCO network time used in the past 3 years.
@@ -273,8 +275,9 @@
                 </template>
                 <template v-else-if="data.proposal_type === 'KEY'">
                   <p>
-                    For the remainder of your proposal, please upload a single pdf file that includes the sections listed below, but <em>not</em> an author list. Consult the Call for
-                    Key Projects for information on the sections (e.g. Plan for management) that are unique to key projects.
+                    For the remainder of your proposal, please upload a single pdf file that includes the sections listed below, but <em>not</em> an
+                    author list. Consult the Call for Key Projects for information on the sections (e.g. Plan for management) that are unique to key
+                    projects.
                   </p>
                   <ul>
                     <li>
@@ -305,7 +308,8 @@
                       additional time on the LCO network from their own institutions, computing resources, or scientist time.
                     </li>
                     <li>
-                      <strong>Report of related programs on other telescopes.</strong> A concise account of other programs that relate to this proposal.
+                      <strong>Report of related programs on other telescopes.</strong> A concise account of other programs that relate to this
+                      proposal.
                     </li>
                     <li>
                       <strong>Report on use of LCO in the past 3 years.</strong> A concise account of LCO network time used in the past 3 years.

--- a/src/views/Observations.vue
+++ b/src/views/Observations.vue
@@ -1,8 +1,8 @@
 <template>
-  <ocs-observations-table 
-    :observationPortalApiBaseUrl="observationPortalApiUrl"
-    :observationDetailLink="generateObservationLink"
-    :requestLink="generateRequestLink"
+  <ocs-observations-table
+    :observation-portal-api-base-url="observationPortalApiUrl"
+    :observation-detail-link="generateObservationLink"
+    :request-link="generateRequestLink"
     @onSuccessfulDataRetrieval="clearErrors"
     @onErrorRetrievingData="setErrorsOnFailedAJAXCall"
   />


### PR DESCRIPTION
Allow a PI to paginate through all of their proposal invitations on the proposal detail page.

Previously just a list of proposals was shown with what was returned from one call to the API, but if a user had more proposal invitations than was returned by the API for a page, they would not be able to access any of the invitations beyond the first page.

This branch is deployed to the dev portal. I've added more than a page worth of proposal invitations to the [LCOSchedulerTest proposal detail page](http://observation-portal-dev.lco.gtn/proposals/LCOSchedulerTest), so you can make yourself a PI on that proposal to test it out. 