### PR TITLE
Simplify logic for determining reduction level in ArchiveTable.

### DIFF
--- a/src/components/ArchiveTable.vue
+++ b/src/components/ArchiveTable.vue
@@ -103,14 +103,8 @@ export default {
           title: 'Reduction',
           sortable: 'true',
           formatter: function(value) {
-            switch (value) {
-              case 0:
-                return 'raw';
-              case 11:
-                return 'quicklook';
-              case 91:
-                return 'reduced';
-            }
+            let reductionString = value === 0 ? 'raw' : 'reduced';
+            return reductionString;
           }
         }
       ]


### PR DESCRIPTION
Curtis keeps finding bugs in things!

From a Slack conversation:

![image](https://user-images.githubusercontent.com/7182533/123001145-4227e300-d365-11eb-903c-28ae043f33ac.png)

I went into the logic and noticed some outdated stuff with respect to reduction levels. Since the portal only reports raw/reduced, I kept that convention. I just updated so that anything not RLEVEL=0 is reduced. Also removed quicklook since that's not a thing anymore.

I couldn't find anything else that referenced quicklook, so I think this is the only place?

I've got this running on http://observation-portal-dev.lco.gtn/

Example request with reduced data: http://observation-portal-dev.lco.gtn/requests/1889951

Also confirmed to work on -92 data: 
![image](https://user-images.githubusercontent.com/7182533/123001722-e1e57100-d365-11eb-87ae-516e9efaf4fb.png)

