### PR TITLE
Feature/tag proposals

### DIFF
--- a/src/components/EditSciApplication.vue
+++ b/src/components/EditSciApplication.vue
@@ -43,7 +43,7 @@
             field="is-student-tag"
             :label="''"
             :errors="apiValidationErrors.tags"
-            checkbox-option-label="The data will be an important component of a PhD thesis"
+            checkbox-option-label="Data from this proposal will be an important component of a PhD thesis"
           ></basic-custom-field>
           <template v-if="data.proposal_type === 'COLAB'">
             <basic-custom-field
@@ -592,7 +592,7 @@ export default {
         pdf: null
       };
       let isStudent = false;
-      if (sciApp.tags.indexOf('student') >= 0) {
+      if (sciApp.tags.includes('student')) {
         isStudent = true;
       }
       if (_.get(sciApp, 'timerequest_set', []).length === 0) {

--- a/src/components/EditSciApplication.vue
+++ b/src/components/EditSciApplication.vue
@@ -752,21 +752,17 @@ export default {
         formData.append('coinvestigator_set[' + i + ']last_name', coInvestigators[i].last_name || '');
         formData.append('coinvestigator_set[' + i + ']institution', coInvestigators[i].institution || '');
       }
-
-      let tags = _.remove(_.get(this.sciApp, ['tags'], []), function(i) {
+      // Add tags onto the form data if there are any
+      let tags = _.remove(_.get(this.sciApp, ['tags'], []), i => {
         return i !== 'student';
       });
-
       if (this.isStudent) {
-        tags.push('student')
+        tags.push('student');
       }
-      if (tags.length === 0) {
-        // TODO: Figure out how to pass through an empty list. This results in a 400 from the backend
-        formData.append('tags', []);
-      } else {
-        formData.append('tags', tags);
+      for (let tag of tags) {
+        formData.append('tags', tag);
       }
-
+      // Add pdf fields
       if (this.sciApp.pdf) {
         formData.append('pdf', this.sciApp.pdf);
       }

--- a/src/components/util/BasicCustomField.vue
+++ b/src/components/util/BasicCustomField.vue
@@ -31,6 +31,17 @@
         @input="input($event)"
         @blur="blur($event)"
       ></b-form-file>
+      <b-form-checkbox
+        v-else-if="fieldType === 'checkbox'"
+        :id="fieldId"
+        :checked="value"
+        :state="validationState"
+        :aria-describedby="helpId + ' ' + feedbackId"
+        v-bind="$attrs"
+        @input="input($event)"
+        @blur="blur($event)"
+      >
+      </b-form-checkbox>
       <b-form-input
         v-else
         :id="fieldId"
@@ -61,13 +72,20 @@ export default {
   props: {
     fieldType: {
       validator: function(value) {
-        return value === 'textarea' || value === 'select' || value === 'file' || value === 'input';
+        return value === 'textarea' || value === 'select' || value === 'file' || value === 'input' || value === 'checkbox';
       },
       default: 'input'
     },
     value: {
       validator: function(value) {
-        return value === null || value === undefined || typeof value === 'string' || typeof value === 'number' || typeof value === 'object';
+        return (
+          value === null ||
+          value === undefined ||
+          typeof value === 'string' ||
+          typeof value === 'number' ||
+          typeof value === 'object' ||
+          typeof value === 'boolean'
+        );
       },
       required: true
     },

--- a/src/components/util/BasicCustomField.vue
+++ b/src/components/util/BasicCustomField.vue
@@ -1,6 +1,12 @@
 <template>
   <span>
-    <b-form-group :id="field + '-fieldgroup'" :label-for="fieldId" :label="label" :label-sr-only="labelSrOnly">
+    <b-form-group
+      :id="field + '-fieldgroup'"
+      :label-for="fieldId"
+      :label="label"
+      :label-sr-only="labelSrOnly"
+      :description="description"
+    >
       <b-form-textarea
         v-if="fieldType === 'textarea'"
         :id="fieldId"
@@ -41,6 +47,7 @@
         @input="input($event)"
         @blur="blur($event)"
       >
+        {{ checkboxOptionLabel }}
       </b-form-checkbox>
       <b-form-input
         v-else
@@ -92,6 +99,14 @@ export default {
     label: {
       type: String,
       required: true
+    },
+    description: {
+      type: String,
+      default: ''
+    },
+    checkboxOptionLabel: {
+      type: String,
+      default: ''
     },
     field: {
       type: String,

--- a/src/components/util/BasicCustomField.vue
+++ b/src/components/util/BasicCustomField.vue
@@ -1,12 +1,6 @@
 <template>
   <span>
-    <b-form-group
-      :id="field + '-fieldgroup'"
-      :label-for="fieldId"
-      :label="label"
-      :label-sr-only="labelSrOnly"
-      :description="description"
-    >
+    <b-form-group :id="field + '-fieldgroup'" :label-for="fieldId" :label="label" :label-sr-only="labelSrOnly" :description="description">
       <b-form-textarea
         v-if="fieldType === 'textarea'"
         :id="fieldId"

--- a/src/views/ProposalDetail.vue
+++ b/src/views/ProposalDetail.vue
@@ -34,7 +34,9 @@
           <b-col md="4" cols="12">
             <template v-if="data.tags.length > 0">
               <span class="font-weight-bolder">Proposal Tags</span>
-              <div><b-badge v-for="tag in data.tags" :key="tag" variant="primary" class="mr-1">{{ tag }}</b-badge></div>
+              <div>
+                <b-badge v-for="tag in data.tags" :key="tag" variant="primary" class="mr-1">{{ tag }}</b-badge>
+              </div>
               <br />
             </template>
             <span class="font-weight-bolder"> Email Notifications </span>

--- a/src/views/ProposalDetail.vue
+++ b/src/views/ProposalDetail.vue
@@ -10,7 +10,6 @@
             <h3>
               {{ data.id }} <small>{{ data.title }}</small>
             </h3>
-            <p>Tags: {{ data.tags }}</p>
             <p>{{ data.abstract }}</p>
             <template v-if="principleInvestigators.length === 1">
               <span class="font-weight-bolder">
@@ -33,13 +32,19 @@
             </template>
           </b-col>
           <b-col md="4" cols="12">
-            <span class="font-weight-bolder"> Email Notifications </span
-            ><sup
+            <template v-if="data.tags.length > 0">
+              <span class="font-weight-bolder">Proposal Tags</span>
+              <div><b-badge v-for="tag in data.tags" :key="tag" variant="primary" class="mr-1">{{ tag }}</b-badge></div>
+              <br />
+            </template>
+            <span class="font-weight-bolder"> Email Notifications </span>
+            <sup
               v-b-tooltip="tooltipConfig"
               class="text-primary"
               title="If notifications are enabled, you will receive notifications whenever a requested observation on this proposal is completed."
-              >?</sup
             >
+              ?
+            </sup>
             <b-form @submit="updateProposalNotification">
               <b-form-group id="checkbox-group-proposal-notification" label-for="checkbox-proposal-notification">
                 <b-form-checkbox id="checkbox-proposal-notification" v-model="proposalNotification.enabled">

--- a/src/views/ProposalDetail.vue
+++ b/src/views/ProposalDetail.vue
@@ -32,7 +32,7 @@
             </template>
           </b-col>
           <b-col md="4" cols="12">
-            <template v-if="data.tags.length > 0">
+            <template v-if="data.tags && data.tags.length > 0">
               <span class="font-weight-bolder">Proposal Tags</span>
               <div>
                 <b-badge v-for="tag in data.tags" :key="tag" variant="primary" class="mr-1">{{ tag }}</b-badge>

--- a/src/views/ProposalDetail.vue
+++ b/src/views/ProposalDetail.vue
@@ -10,6 +10,7 @@
             <h3>
               {{ data.id }} <small>{{ data.title }}</small>
             </h3>
+            <p>Tags: {{ data.tags }}</p>
             <p>{{ data.abstract }}</p>
             <template v-if="principleInvestigators.length === 1">
               <span class="font-weight-bolder">

--- a/src/views/ProposalList.vue
+++ b/src/views/ProposalList.vue
@@ -30,14 +30,29 @@
     </b-row>
     <b-row>
       <b-col>
-        <b-form inline @submit="onSubmit">
-          <label class="mr-1" for="input-proposal-active">Proposal is active:</label>
-          <b-form-select id="input-proposal-active" v-model="queryParams.active" :options="proposalActiveOptions" />
-          <label class="m-1" for="input-proposal-semester">Semester:</label>
-          <b-form-select id="input-proposal-semester" v-model="queryParams.semester" :options="semesterOptions"></b-form-select>
-          <label for="select-proposal-tag" class="m-1">Proposal tag:</label>
-          <b-form-select id="select-proposal-tag" v-model="queryParams.tag" :options="tagOptions" />
-          <b-button type="submit" class="m-1" variant="outline-primary" :disabled="isBusy">Filter</b-button>
+        <b-form inline @submit="onSubmit" class="p-1">
+          <b-form-group
+            id="input-group-proposal-active"
+            label="Proposal is active:"
+            label-for="input-proposal-active"
+          >
+            <b-form-select class="mx-1" id="input-proposal-active" v-model="queryParams.active" :options="proposalActiveOptions" />
+          </b-form-group>
+          <b-form-group
+            id="input-group-proposal-semester"
+            label="Semester:"
+            label-for="input-proposal-semester"
+          >
+            <b-form-select class="mx-1" id="input-proposal-semester" v-model="queryParams.semester" :options="semesterOptions"></b-form-select>
+          </b-form-group>
+          <b-form-group
+            id="input-group-proposal-tags"
+            label="Tags:"
+            label-for="input-proposal-tags"
+          >
+            <b-form-select class="mx-1" id="select-proposal-tags" v-model="selectedTags" :options="tagOptions" multiple :select-size="3" />
+          </b-form-group>
+          <b-button type="submit" class="mx-1" variant="outline-primary" :disabled="isBusy">Filter</b-button>
         </b-form>
         <b-table id="proposals-table" :items="data.results" :fields="fields" :busy="isBusy" show-empty striped responsive>
           <template v-slot:table-busy>
@@ -132,6 +147,16 @@ export default {
     },
     userProposals: function() {
       return this.$store.state.profile.proposals;
+    },
+    selectedTags: {
+      // The multi select represents the tags as strings in an array, but the observation portal
+      // API expects a string with a commas separated list of tags
+      get: function() {
+        return _.split(this.queryParams.tags, ',');
+      },
+      set: function(newValue) {
+        this.queryParams.tags = _.join(newValue, ',');
+      }
     }
   },
   created: function() {
@@ -147,7 +172,7 @@ export default {
       const defaultQueryParams = {
         active: 'True',
         semester: '',
-        tag: '',
+        tags: '',
         limit: 50,
         offset: 0
       };

--- a/src/views/ProposalList.vue
+++ b/src/views/ProposalList.vue
@@ -31,13 +31,13 @@
     <b-row>
       <b-col>
         <b-form inline @submit="onSubmit">
-          <label class="mr-sm-2" for="input-proposal-tag">Proposal tag:</label>
-          <b-form-input id="input-proposal-tag" v-model="queryParams.tag" />
-          <label class="mr-sm-2" for="input-proposal-active">Proposal is active:</label>
+          <label class="mr-1" for="input-proposal-active">Proposal is active:</label>
           <b-form-select id="input-proposal-active" v-model="queryParams.active" :options="proposalActiveOptions" />
-          <label class="m-sm-2" for="input-proposal-semester">Semester:</label>
+          <label class="m-1" for="input-proposal-semester">Semester:</label>
           <b-form-select id="input-proposal-semester" v-model="queryParams.semester" :options="semesterOptions"></b-form-select>
-          <b-button type="submit" class="m-sm-1" variant="outline-primary" :disabled="isBusy">Filter</b-button>
+          <label for="select-proposal-tag" class="m-1">Proposal tag:</label>
+          <b-form-select id="select-proposal-tag" v-model="queryParams.tag" :options="tagOptions" />
+          <b-button type="submit" class="m-1" variant="outline-primary" :disabled="isBusy">Filter</b-button>
         </b-form>
         <b-table id="proposals-table" :items="data.results" :fields="fields" :busy="isBusy" show-empty striped responsive>
           <template v-slot:table-busy>
@@ -100,6 +100,7 @@ export default {
         { value: 'False', text: 'False' },
         { value: 'True', text: 'True' }
       ],
+      tagOptions: [{value: '', text: '-----'}],
       proposalsFilters: {
         active: '',
         semester: ''
@@ -136,6 +137,7 @@ export default {
   created: function() {
     this.getSemesters();
     this.getCalls();
+    this.getTagOptions();
   },
   methods: {
     initializeDataEndpoint: function() {
@@ -145,10 +147,22 @@ export default {
       const defaultQueryParams = {
         active: 'True',
         semester: '',
+        tag: '',
         limit: 50,
         offset: 0
       };
       return defaultQueryParams;
+    },
+    getTagOptions: function() {
+      $.ajax({
+        url: this.observationPortalApiUrl + '/api/proposals/tags/'
+      }).done(response => {
+        let options = [{value: '', text: '-----'}];
+        for (let tag of response) {
+          options.push({value: tag, text: tag});
+        }
+        this.tagOptions = options;
+      });
     },
     getSemesters: function() {
       let that = this;

--- a/src/views/ProposalList.vue
+++ b/src/views/ProposalList.vue
@@ -31,6 +31,8 @@
     <b-row>
       <b-col>
         <b-form inline @submit="onSubmit">
+          <label class="mr-sm-2" for="input-proposal-tag">Proposal tag:</label>
+          <b-form-input id="input-proposal-tag" v-model="queryParams.tag" />
           <label class="mr-sm-2" for="input-proposal-active">Proposal is active:</label>
           <b-form-select id="input-proposal-active" v-model="queryParams.active" :options="proposalActiveOptions" />
           <label class="m-sm-2" for="input-proposal-semester">Semester:</label>

--- a/src/views/ProposalList.vue
+++ b/src/views/ProposalList.vue
@@ -100,7 +100,7 @@ export default {
         { value: 'False', text: 'False' },
         { value: 'True', text: 'True' }
       ],
-      tagOptions: [{value: '', text: '-----'}],
+      tagOptions: [{ value: '', text: '-----' }],
       proposalsFilters: {
         active: '',
         semester: ''
@@ -157,9 +157,9 @@ export default {
       $.ajax({
         url: this.observationPortalApiUrl + '/api/proposals/tags/'
       }).done(response => {
-        let options = [{value: '', text: '-----'}];
+        let options = [{ value: '', text: '-----' }];
         for (let tag of response) {
-          options.push({value: tag, text: tag});
+          options.push({ value: tag, text: tag });
         }
         this.tagOptions = options;
       });

--- a/src/views/ProposalList.vue
+++ b/src/views/ProposalList.vue
@@ -30,27 +30,22 @@
     </b-row>
     <b-row>
       <b-col>
-        <b-form inline @submit="onSubmit" class="p-1">
-          <b-form-group
-            id="input-group-proposal-active"
-            label="Proposal is active:"
-            label-for="input-proposal-active"
-          >
-            <b-form-select class="mx-1" id="input-proposal-active" v-model="queryParams.active" :options="proposalActiveOptions" />
+        <b-form inline class="p-1" @submit="onSubmit">
+          <b-form-group id="input-group-proposal-active" label="Proposal is active:" label-for="input-proposal-active">
+            <b-form-select id="input-proposal-active" v-model="queryParams.active" class="mx-1" :options="proposalActiveOptions" />
           </b-form-group>
-          <b-form-group
-            id="input-group-proposal-semester"
-            label="Semester:"
-            label-for="input-proposal-semester"
-          >
-            <b-form-select class="mx-1" id="input-proposal-semester" v-model="queryParams.semester" :options="semesterOptions"></b-form-select>
+          <b-form-group id="input-group-proposal-semester" label="Semester:" label-for="input-proposal-semester">
+            <b-form-select id="input-proposal-semester" v-model="queryParams.semester" class="mx-1" :options="semesterOptions"></b-form-select>
           </b-form-group>
-          <b-form-group
-            id="input-group-proposal-tags"
-            label="Tags:"
-            label-for="input-proposal-tags"
-          >
-            <b-form-select class="mx-1" id="select-proposal-tags" v-model="selectedTags" :options="tagOptions" multiple :select-size="3" />
+          <b-form-group id="input-group-proposal-tags" label="Tags:" label-for="input-proposal-tags">
+            <b-form-select
+              id="select-proposal-tags"
+              v-model="selectedTags"
+              class="mx-1"
+              :options="tagOptions"
+              multiple
+              :select-size="tagsSelectSize"
+            />
           </b-form-group>
           <b-button type="submit" class="mx-1" variant="outline-primary" :disabled="isBusy">Filter</b-button>
         </b-form>
@@ -157,6 +152,9 @@ export default {
       set: function(newValue) {
         this.queryParams.tags = _.join(newValue, ',');
       }
+    },
+    tagsSelectSize: function() {
+      return Math.min(this.tagOptions.length, 2);
     }
   },
   created: function() {


### PR DESCRIPTION
Allow users submitting a science application to select whether an application is for a student thesis. Besides that:

- If a proposal has tags, those tags are displayed on the proposal detail page
- Another filter has been added to the proposal list page to allow a user to filter for a specific proposal tag

This branch is running here http://172.16.4.73:8080/ (corresponding backend running here http://172.16.4.73:8000/). The backend has a snapshot of prod so you should be able to log in with you usual credentials. I've already created a science application and proposal with a tag so you can see how those look.