### PR TITLE
Add fractional_ephemeris_rate field into the compose page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10362,7 +10362,7 @@
       "dev": true
     },
     "ocs-component-lib": {
-      "version": "0.12.2",
+      "version": "0.12.3",
       "requires": {
         "core-js": "^3.6.5",
         "vue": "^2.6.11"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jquery-file-download": "^1.4.6",
     "lodash": "^4.17.13",
     "moment": "^2.22.1",
-    "ocs-component-lib": "^0.12.2",
+    "ocs-component-lib": "^0.12.3",
     "pdf-lib": "^1.12.0",
     "popper.js": "^1.16.1",
     "vis": "4.19.1",

--- a/src/views/Compose.vue
+++ b/src/views/Compose.vue
@@ -172,6 +172,19 @@
                   </div>
                 </ocs-custom-field>
               </template>
+              <template #target-fields-footer="slotProps">
+                  <span v-show="showFractionalRate(slotProps.data.target)">
+                    <ocs-custom-field
+                      key="fractional_ephemeris_rate"
+                      v-model="slotProps.data.target.extra_params['fractional_ephemeris_rate']"
+                      field="fractional_ephemeris_rate"
+                      label="Fractional Ephemeris Rate"
+                      desc="Fractional rate at which to track the object relative to the stars around it, from 0 to 1"
+                      :errors="slotProps.data.target.errors"
+                      @input="slotProps.update()"
+                    />
+                  </span>
+              </template>
               <template #target-help="slotProps">
                 <archive
                   v-if="slotProps.data.target.ra && slotProps.data.target.dec"
@@ -622,7 +635,8 @@ export default {
                   proper_motion_ra: 0.0,
                   proper_motion_dec: 0.0,
                   epoch: 2000,
-                  parallax: 0
+                  parallax: 0,
+                  extra_params: {}
                 },
                 constraints: {
                   max_airmass: simpleInterface ? 2 : 1.6,
@@ -877,6 +891,13 @@ export default {
     },
     onRequestGroupSaved: function(requestGroupId) {
       this.$router.push({ name: 'requestgroupDetail', params: { id: requestGroupId } });
+    },
+    showFractionalRate: function(target) {
+      if (target.type === 'ORBITAL_ELEMENTS' && !target.scheme.includes('MAJOR_PLANET')) {
+        return true;
+      }
+      delete target.extra_params['fractional_ephemeris_rate']
+      return false;
     },
     doTargetLookup: _.debounce(function(target, callback) {
       this.targetLookup.busy = true;

--- a/src/views/Compose.vue
+++ b/src/views/Compose.vue
@@ -691,7 +691,9 @@ export default {
       if (target.type === 'ORBITAL_ELEMENTS' && !target.scheme.includes('MAJOR_PLANET')) {
         return true;
       }
-      delete target.extra_params['fractional_ephemeris_rate']
+      else if (target.extra_params) {
+        delete target.extra_params['fractional_ephemeris_rate'];
+      }
       return false;
     },
     selectedInstruments: function() {

--- a/src/views/Compose.vue
+++ b/src/views/Compose.vue
@@ -173,6 +173,7 @@
                 </ocs-custom-field>
               </template>
               <template #target-fields-footer="slotProps">
+                  <!-- This showFractionalRate has a side effect of clearing out the fractional_ephemeris_rate from the extra_params if it doesn't show -->
                   <span v-show="showFractionalRate(slotProps.data.target)">
                     <ocs-custom-field
                       key="fractional_ephemeris_rate"
@@ -686,6 +687,13 @@ export default {
       }
       return nActiveProposals > 0 ? true : false;
     },
+    showFractionalRate: function(target) {
+      if (target.type === 'ORBITAL_ELEMENTS' && !target.scheme.includes('MAJOR_PLANET')) {
+        return true;
+      }
+      delete target.extra_params['fractional_ephemeris_rate']
+      return false;
+    },
     selectedInstruments: function() {
       // Return object where the first key is the requestIndex and the second is the configurationIndex
       let _selectedInstruments = {};
@@ -891,13 +899,6 @@ export default {
     },
     onRequestGroupSaved: function(requestGroupId) {
       this.$router.push({ name: 'requestgroupDetail', params: { id: requestGroupId } });
-    },
-    showFractionalRate: function(target) {
-      if (target.type === 'ORBITAL_ELEMENTS' && !target.scheme.includes('MAJOR_PLANET')) {
-        return true;
-      }
-      delete target.extra_params['fractional_ephemeris_rate']
-      return false;
     },
     doTargetLookup: _.debounce(function(target, callback) {
       this.targetLookup.busy = true;

--- a/src/views/Compose.vue
+++ b/src/views/Compose.vue
@@ -687,15 +687,6 @@ export default {
       }
       return nActiveProposals > 0 ? true : false;
     },
-    showFractionalRate: function(target) {
-      if (target.type === 'ORBITAL_ELEMENTS' && !target.scheme.includes('MAJOR_PLANET')) {
-        return true;
-      }
-      else if (target.extra_params) {
-        delete target.extra_params['fractional_ephemeris_rate'];
-      }
-      return false;
-    },
     selectedInstruments: function() {
       // Return object where the first key is the requestIndex and the second is the configurationIndex
       let _selectedInstruments = {};
@@ -901,6 +892,15 @@ export default {
     },
     onRequestGroupSaved: function(requestGroupId) {
       this.$router.push({ name: 'requestgroupDetail', params: { id: requestGroupId } });
+    },
+    showFractionalRate: function(target) {
+      if (target.type === 'ORBITAL_ELEMENTS' && !target.scheme.includes('MAJOR_PLANET')) {
+        return true;
+      }
+      else if (target.extra_params) {
+        delete target.extra_params['fractional_ephemeris_rate'];
+      }
+      return false;
     },
     doTargetLookup: _.debounce(function(target, callback) {
       this.targetLookup.busy = true;

--- a/src/views/Compose.vue
+++ b/src/views/Compose.vue
@@ -180,7 +180,7 @@
                       v-model="slotProps.data.target.extra_params['fractional_ephemeris_rate']"
                       field="fractional_ephemeris_rate"
                       label="Fractional Ephemeris Rate"
-                      desc="Fractional rate at which to track the object relative to the stars around it, from 0 to 1"
+                      desc="Fraction of the target's motion that will be used for tracking. Must be a value from 0.0 (Sidereal Tracking) to 1.0 (Target Tracking). See the Getting Started guide for suggestions on how to counter target drift."
                       :errors="slotProps.data.target.errors"
                       @input="slotProps.update()"
                     />


### PR DESCRIPTION
This uses the `target-fields-footer` slot from here: https://github.com/observatorycontrolsystem/ocs-component-lib/pull/22 to add the `fractional_ephemeris_rate` field if its a non-major planet orbital elements type target. 

This took me a little while to figure out and I still don't fully understand how this vue stuff works, but this seems to do what I want when I'm testing locally. 