### PR TITLE
Fix links to Getting Started Guide

### DIFF
--- a/src/views/Apply.vue
+++ b/src/views/Apply.vue
@@ -25,7 +25,7 @@
       <p>
         If you are composing a proposal for the LCO network for the first time, we recommend that you consult our
         <a href="https://lco.global/observatory/proposal/guidelines/">guidelines for writing proposals,</a> as well as the
-        <a href="https://lco.global/documents/1175/GettingStartedontheLCONetwork.latest.pdf">"Getting Started" Guide.</a> Information about the
+        <a href="https://lco.global/documents/1242/GettingStartedontheLCONetwork.latest.pdf">"Getting Started" Guide.</a> Information about the
         <a href="//lco.global/observatory/telescopes">telescopes</a>, <a href="//lco.global/observatory/instruments">instruments</a>,
         <a href="//lco.global/observatory/data">data handling and quality</a>, <a href="//lco.global/observatory/scheduling">scheduling</a> and other
         technical aspects of the network is available on the <a href="https://lco.global/observatory/">observatory capabilities</a> pages.

--- a/src/views/Compose.vue
+++ b/src/views/Compose.vue
@@ -6,7 +6,7 @@
         <ocs-custom-alert v-show="!isMemberOfActiveProposals" alert-class="danger" :dismissible="false">
           <p>
             You must be a member of a currently active proposal in order to create and submit observation requests. You can review the
-            <a href="https://lco.global/documents/1175/GettingStartedontheLCONetwork.latest.pdf">getting started guide</a> or the
+            <a href="https://lco.global/documents/1242/GettingStartedontheLCONetwork.latest.pdf">getting started guide</a> or the
             <a href="https://lco.global/observatory/proposal/process/">proposal process documentation</a> to see how to become a member of a proposal.
           </p>
         </ocs-custom-alert>

--- a/src/views/Help.vue
+++ b/src/views/Help.vue
@@ -41,7 +41,7 @@
       </ul>
       <p>
         If you are a new user of this Observation Portal, we strongly recommend that you read the
-        <a href="https://lco.global/documents/1175/GettingStartedontheLCONetwork.latest.pdf"
+        <a href="https://lco.global/documents/1242/GettingStartedontheLCONetwork.latest.pdf"
           >"Getting Started on the LCO Global Telescope Network" Guide.</a
         >
       </p>


### PR DESCRIPTION
The Feb 2022 version of the Getting Started Guide was deployed on Feb 1.