### PR TITLE
Add Co-Investigator Time Allocation Information

### DIFF
--- a/src/views/ProposalDetail.vue
+++ b/src/views/ProposalDetail.vue
@@ -180,7 +180,7 @@
         </template>
       </b-col>
     </b-row>
-    <h2>Time Allocation</h2>
+    <h2>Project Time Allocation</h2>
     <b-row>
       <b-col>
         <div class="table-responsive">

--- a/src/views/ProposalDetail.vue
+++ b/src/views/ProposalDetail.vue
@@ -161,13 +161,13 @@
             </small>
           </h2>
           <b-collapse id="collapse-coi-time-allocation" class="w-100" visible>
-            <b-col md="9" v-if="coInvestigatorHasNoTimeLimit" class="mb-4">
+            <b-col v-if="coInvestigatorHasNoTimeLimit" md="9" class="mb-4">
               <span>
-                {{ coInvestigatorTimeInformation.timeUsed | formatFloat(1) }} hours used.
-                The Principal Investigator has not set a time limit for this Co-Investigator.
+                {{ coInvestigatorTimeInformation.timeUsed | formatFloat(1) }} hours used. The Principal Investigator has not set a time limit for this
+                Co-Investigator.
               </span>
             </b-col>
-            <b-col md="9" v-else>
+            <b-col v-else md="9">
               <span>
                 {{ coInvestigatorTimeInformation.timeUsed | formatFloat(1) }} hours used /
                 {{ coInvestigatorTimeInformation.timeLimit | formatFloat(1) }} hours allocated
@@ -350,7 +350,7 @@ export default {
       return this.coInvestigatorTimeInformation.role === 'CI' ? true : false;
     },
     coInvestigatorHasNoTimeLimit: function() {
-      return this.coInvestigatorTimeInformation.timeLimit === -1 ? true: false;
+      return this.coInvestigatorTimeInformation.timeLimit === -1 ? true : false;
     },
     timeAllocationsBySemesterAsList: function() {
       let groupedTimeAllocationsBySemester = _.groupBy(this.data.timeallocation_set, 'semester');

--- a/src/views/ProposalDetail.vue
+++ b/src/views/ProposalDetail.vue
@@ -75,8 +75,8 @@
       </b-col>
     </b-row>
     <b-row>
+      <hr class="w-100" />
       <template v-if="userIsPI">
-        <hr class="w-100" />
         <b-col>
           <h4>
             Co-Investigators
@@ -450,28 +450,28 @@ export default {
       this.setGlobalMembershipLimit(-1);
       this.globallimit.timeLimit = null;
     },
-    updateCoInvestigatorTimeAllocationInformation: function(data) {
+    updateCoInvestigatorTimeInformation: function(data) {
       if (data.results.length > 0) {
         let timeLimit = 0;
         let timeUsed = 0;
-        // there should only be one result, but future-proof this just in case
+        // in most cases there will only be one result, but handle multiple
         for (let result of data.results) {
           timeLimit += result.time_limit;
           timeUsed += result.time_used_by_user;
         }
+        // convert from seconds to hours
         this.coInvestigatorTimeInformation.timeLimit = Math.floor(timeLimit / 3600);
         this.coInvestigatorTimeInformation.timeUsed = Math.floor(timeUsed / 3600);
         this.coInvestigatorTimeInformation.role = 'CI';
       }
     },
     getCoInvestigatorTimeAllocationInformation: function() {
-      let that = this;
       $.ajax({
         method: 'GET',
         url: this.observationPortalApiUrl + '/api/memberships/',
         data: { proposal: this.id, username: this.$store.state.profile.username, role: 'CI' }
-      }).done(function(data) {
-        that.updateCoInvestigatorTimeAllocationInformation(data);
+      }).done(data => {
+        this.updateCoInvestigatorTimeInformation(data);
       });
     }
   }

--- a/src/views/ProposalDetail.vue
+++ b/src/views/ProposalDetail.vue
@@ -151,7 +151,7 @@
     <b-row>
       <b-col>
         <template v-if="userIsCI">
-          <h4>
+          <h2>
             Co-Investigator Time Allocation
             <small>
               <b-link v-b-toggle.collapse-coi-time-allocation href="#">
@@ -159,9 +159,15 @@
                 <span class="when-closed"><i class="fa fa-eye fa-eye-slash"></i></span>
               </b-link>
             </small>
-          </h4>
+          </h2>
           <b-collapse id="collapse-coi-time-allocation" class="w-100" visible>
-            <b-col md="9">
+            <b-col md="9" v-if="coInvestigatorHasNoTimeLimit" class="mb-4">
+              <span>
+                {{ coInvestigatorTimeInformation.timeUsed | formatFloat(1) }} hours used.
+                The Principal Investigator has not set a time limit for this Co-Investigator.
+              </span>
+            </b-col>
+            <b-col md="9" v-else>
               <span>
                 {{ coInvestigatorTimeInformation.timeUsed | formatFloat(1) }} hours used /
                 {{ coInvestigatorTimeInformation.timeLimit | formatFloat(1) }} hours allocated
@@ -342,6 +348,9 @@ export default {
     },
     userIsCI: function() {
       return this.coInvestigatorTimeInformation.role === 'CI' ? true : false;
+    },
+    coInvestigatorHasNoTimeLimit: function() {
+      return this.coInvestigatorTimeInformation.timeLimit === -1 ? true: false;
     },
     timeAllocationsBySemesterAsList: function() {
       let groupedTimeAllocationsBySemester = _.groupBy(this.data.timeallocation_set, 'semester');

--- a/src/views/ProposalDetail.vue
+++ b/src/views/ProposalDetail.vue
@@ -151,7 +151,7 @@
     <b-row>
       <b-col>
         <template v-if="userIsCI">
-          <h2>
+          <h4>
             Co-Investigator Time Allocation
             <small>
               <b-link v-b-toggle.collapse-coi-time-allocation href="#">
@@ -159,7 +159,7 @@
                 <span class="when-closed"><i class="fa fa-eye fa-eye-slash"></i></span>
               </b-link>
             </small>
-          </h2>
+          </h4>
           <b-collapse id="collapse-coi-time-allocation" class="w-100" visible>
             <b-col v-if="coInvestigatorHasNoTimeLimit" md="9" class="mb-4">
               <span>


### PR DESCRIPTION
This adds information to the proposal detail page for Co-Investigators so that they can see how much time they've been allotted and how much they've used.

There are three cases:
1. User is a PI - this is not shown. Nothing has changed.
2. User is a CI _with_ a time limit - a progress bar with hours used/hours allocated is shown
3. User is a CI _without_ a time limit -  Hours used are shown, and a message _"The Principal Investigator has not set a time limit for this Co-Investigator. "_

I have this deployed to http://observation-portal-dev.lco.gtn

I've set up a few proposals for the eng user (usual sba password) to demo this functionality. Login with eng and visit the following pages:
Case 1: [User is a PI](http://observation-portal-dev.lco.gtn/proposals/TOM%20demo%20scheduler?role=CI&proposal=TOM%20demo%20scheduler)
Case 2: [User is a CI with a time limit](http://observation-portal-dev.lco.gtn/proposals/DDT2021B-001)
Case 3: [User is a CI without a time limit](http://observation-portal-dev.lco.gtn/proposals/urgent_auto_focus)