### PR TITLE
Update archive filters

### DIFF
--- a/src/archive.js
+++ b/src/archive.js
@@ -20,7 +20,7 @@ function downloadZip(frameIds, archiveRoot, archiveToken) {
 }
 
 function downloadAll(requestId, archiveRoot, archiveClientUrl, archiveToken) {
-  $.getJSON(archiveRoot + '/frames/?limit=1000&REQNUM=' + requestId, function(data) {
+  $.getJSON(archiveRoot + '/frames/?limit=1000&request_id=' + requestId, function(data) {
     if (data.count > 1000) {
       alert('Over 1000 products found. Please use ' + archiveClientUrl + ' to download your data');
       return false;
@@ -35,7 +35,7 @@ function downloadAll(requestId, archiveRoot, archiveClientUrl, archiveToken) {
 
 function getLatestFrame(requestId, archiveRoot, callback) {
   $.ajax({
-    url: archiveRoot + '/frames/?ordering=-id&limit=1&REQNUM=' + requestId,
+    url: archiveRoot + '/frames/?ordering=-id&limit=1&request_id=' + requestId,
     dataType: 'json'
   }).done(function(response) {
     callback(response.results[0]);

--- a/src/components/Archive.vue
+++ b/src/components/Archive.vue
@@ -31,7 +31,7 @@ export default {
   },
   computed: {
     guiLink: function() {
-      return this.$store.state.urls.archiveClient + '/?OBSTYPE=EXPOSE&start=2014-05-01&covers=POINT(' + this.ra + ' ' + this.dec + ')';
+      return this.$store.state.urls.archiveClient + '/?configuration_type=EXPOSE&start=2014-05-01&covers=POINT(' + this.ra + ' ' + this.dec + ')';
     },
     archiveApiUrl: function() {
       return this.$store.state.urls.archiveApi;

--- a/src/components/Archive.vue
+++ b/src/components/Archive.vue
@@ -55,7 +55,7 @@ export default {
   methods: {
     setResultCount: _.debounce(function() {
       let that = this;
-      $.getJSON(this.archiveApiUrl + '/frames/?OBSTYPE=EXPOSE&covers=POINT(' + that.ra + ' ' + that.dec + ')', function(data) {
+      $.getJSON(this.archiveApiUrl + '/frames/?configuration_type=EXPOSE&covers=POINT(' + that.ra + ' ' + that.dec + ')', function(data) {
         that.resultCount = data.count;
       });
     }, 500)

--- a/src/components/ArchiveTable.vue
+++ b/src/components/ArchiveTable.vue
@@ -78,7 +78,7 @@ export default {
           sortable: 'true'
         },
         {
-          field: 'DATE_OBS',
+          field: 'observation_date',
           title: 'DATE_OBS',
           sortable: 'true',
           formatter: function(value) {
@@ -86,17 +86,17 @@ export default {
           }
         },
         {
-          field: 'FILTER',
+          field: 'primary_optical_element',
           title: 'filter',
           sortable: 'true'
         },
         {
-          field: 'OBSTYPE',
+          field: 'configuration_type',
           title: 'obstype',
           sortable: 'true'
         },
         {
-          field: 'RLEVEL',
+          field: 'reduction_level',
           title: 'Reduction',
           sortable: 'true',
           formatter: function(value) {

--- a/src/components/ArchiveTable.vue
+++ b/src/components/ArchiveTable.vue
@@ -30,7 +30,7 @@ export default {
       return this.$store.state.urls.archiveClient;
     },
     archiveLink: function() {
-      return this.archiveClientUrl + '/?REQNUM=' + this.requestid + '&start=2014-01-01';
+      return this.archiveClientUrl + '/?request_id=' + this.requestid + '&start=2014-01-01';
     }
   },
   watch: {
@@ -129,7 +129,7 @@ export default {
     refreshTable: function() {
       if (this.requestid) {
         $('#archive-table').bootstrapTable('refresh', {
-          url: this.archiveApiUrl + '/frames/?limit=1000&exclude_OBSTYPE=GUIDE&REQNUM=' + this.requestid
+          url: this.archiveApiUrl + '/frames/?limit=1000&exclude_configuration_type=GUIDE&request_id=' + this.requestid
         });
       }
     }

--- a/src/components/RequestDetail.vue
+++ b/src/components/RequestDetail.vue
@@ -163,7 +163,7 @@ export default {
         blue: ['B']
       };
       let filtersUsed = this.frames.map(function(frame) {
-        return frame.FILTER;
+        return frame.primary_optical_element;
       });
       let numColors = 0;
       for (let color in colorFilters) {

--- a/src/views/ProposalDetail.vue
+++ b/src/views/ProposalDetail.vue
@@ -333,7 +333,7 @@ export default {
       return this.$store.state.urls.observationPortalApi;
     },
     archiveLink: function() {
-      return this.$store.state.urls.archiveClient + '?PROPID=' + this.id;
+      return this.$store.state.urls.archiveClient + '?proposal_id=' + this.id;
     },
     principleInvestigators: function() {
       return _.get(this.data, 'pis', []);


### PR DESCRIPTION
This isn't needed immediately but we should deploy this before removing the old filters and fields from the archive frames response.