### PR TITLE
Feature/copy sciapp

### DIFF
--- a/src/components/EditSciApplication.vue
+++ b/src/components/EditSciApplication.vue
@@ -244,8 +244,8 @@
               <div class="help-block">
                 <template v-if="data.proposal_type === 'SCI'">
                   <p>
-                    For the remainder of your proposal, please upload a single pdf file that includes the following sections <em>but not an
-                    author list</em>:
+                    For the remainder of your proposal, please upload a single pdf file that includes the following sections
+                    <em>but not an author list</em>:
                   </p>
                   <ul>
                     <li>
@@ -286,9 +286,9 @@
                 </template>
                 <template v-else-if="data.proposal_type === 'KEY'">
                   <p>
-                    For the remainder of your proposal, please upload a single pdf file that includes the sections listed below, <em>but not an
-                    author list</em>. Consult the Call for Key Projects for information on the sections (e.g. Plan for management) that are unique to key
-                    projects.
+                    For the remainder of your proposal, please upload a single pdf file that includes the sections listed below,
+                    <em>but not an author list</em>. Consult the Call for Key Projects for information on the sections (e.g. Plan for management) that
+                    are unique to key projects.
                   </p>
                   <ul>
                     <li>

--- a/src/components/SciApplications.vue
+++ b/src/components/SciApplications.vue
@@ -88,8 +88,15 @@
           <span class="text-primary mx-auto"><i class="far fa-file-pdf"></i></span>
         </router-link>
       </template>
-      <template #cell(copy)="data" v-if="!isSciCollab">
-        <b-button :disabled="cannotCopy(data.item.id)" @click="copyScienceApplication(data.item.id)" variant="link" size="sm" v-b-tooltip.hover title="Copy Science Application as draft for current Call">
+      <template v-if="!isSciCollab" #cell(copy)="data">
+        <b-button
+          v-b-tooltip.hover
+          :disabled="cannotCopy(data.item.id)"
+          variant="link"
+          size="sm"
+          title="Copy Science Application as draft for current Call"
+          @click="copyScienceApplication(data.item.id)"
+        >
           <b-icon icon="stickies" flip-v shift-v="3" aria-hidden="true"></b-icon>
         </b-button>
       </template>
@@ -209,7 +216,7 @@ export default {
       this.$store.commit('clearNamespacedMessages', 'scicollab-applications');
     },
     cannotCopy: function(applicationId) {
-      var scienceApplication = _.find(this.submittedApplications, ["id", applicationId]);
+      var scienceApplication = _.find(this.submittedApplications, ['id', applicationId]);
       if (scienceApplication) {
         return !this.openCallTypes.includes(scienceApplication.call.proposal_type);
       }
@@ -227,8 +234,11 @@ export default {
           that.addMessage('Science Application Copied', 'success');
           that.getData();
         })
-        .fail(function(response) {
-          that.addMessage('There was a problem copying the science application. Please ensure there is an open call of the same type and try again', 'danger');
+        .fail(function() {
+          that.addMessage(
+            'There was a problem copying the science application. Please ensure there is an open call of the same type and try again',
+            'danger'
+          );
         });
     },
     getDeleteConfirmationMessage: function(title) {

--- a/src/components/SciApplications.vue
+++ b/src/components/SciApplications.vue
@@ -173,9 +173,6 @@ export default {
         return app.status !== 'DRAFT';
       });
     },
-    cannotCopy: function(applicationId) {
-      return !this.openCallTypes.includes(_.find(this.submittedApplications(), function (item) { return item.id == applicationId; }).call.proposal_type);
-    },
     draftApplications: function() {
       return _.filter(this.data.results, app => {
         return app.status === 'DRAFT';
@@ -209,12 +206,19 @@ export default {
     clearMessages: function() {
       this.$store.commit('clearNamespacedMessages', 'scicollab-applications');
     },
+    cannotCopy: function(applicationId) {
+      var scienceApplication = _.find(this.submittedApplications, ["id", applicationId]);
+      if (scienceApplication) {
+        return !this.openCallTypes.includes(scienceApplication.call.proposal_type);
+      }
+      return true;
+    },
     copyScienceApplication: function(applicationId) {
       this.clearMessages();
       var that = this;
       $.ajax({
         type: 'POST',
-        url: `${this.observationPortalApiBaseUrl}/api/scienceapplications/${appilcationId}/copy/`,
+        url: `${this.observationPortalApiUrl}/api/scienceapplications/${applicationId}/copy/`,
         contentType: 'application/json'
       })
         .done(function() {

--- a/src/components/SciApplications.vue
+++ b/src/components/SciApplications.vue
@@ -87,6 +87,9 @@
         <router-link :to="{ name: 'appCombinedPdf', params: { sciAppId: data.item.id } }" target="_blank">
           <span class="text-primary mx-auto"><i class="far fa-file-pdf"></i></span>
         </router-link>
+        <b-button :disabled="cannotCopy(data.item.id)" v-b-tooltip.hover size="sm" class="mx-1" variant="success" title="Copy Science Application for current Call" @click="copyScienceApplication(data.item.id)">
+          <i class="fa fa-copy fa-fw" />
+        </b-button>
       </template>
     </b-table>
   </div>
@@ -114,6 +117,13 @@ export default {
       required: true
     },
     sciCollabAllocations: {
+      type: Array,
+      required: false,
+      default: function() {
+        return [];
+      }
+    },
+    openCallTypes: {
       type: Array,
       required: false,
       default: function() {
@@ -163,6 +173,9 @@ export default {
         return app.status !== 'DRAFT';
       });
     },
+    cannotCopy: function(applicationId) {
+      return !this.openCallTypes.includes(_.find(this.submittedApplications(), function (item) { return item.id == applicationId; }).call.proposal_type);
+    },
     draftApplications: function() {
       return _.filter(this.data.results, app => {
         return app.status === 'DRAFT';
@@ -195,6 +208,22 @@ export default {
     },
     clearMessages: function() {
       this.$store.commit('clearNamespacedMessages', 'scicollab-applications');
+    },
+    copyScienceApplication: function(applicationId) {
+      this.clearMessages();
+      var that = this;
+      $.ajax({
+        type: 'POST',
+        url: `${this.observationPortalApiBaseUrl}/api/scienceapplications/${appilcationId}/copy/`,
+        contentType: 'application/json'
+      })
+        .done(function() {
+          that.addMessage('Science Application Copied', 'success');
+          that.getData();
+        })
+        .fail(function(response) {
+          that.addMessage('There was a problem copying the science application. Please ensure there is an open call of the same type and try again', 'danger');
+        });
     },
     getDeleteConfirmationMessage: function(title) {
       return 'Are you sure you want to delete "' + title + '"?';

--- a/src/components/SciApplications.vue
+++ b/src/components/SciApplications.vue
@@ -87,8 +87,10 @@
         <router-link :to="{ name: 'appCombinedPdf', params: { sciAppId: data.item.id } }" target="_blank">
           <span class="text-primary mx-auto"><i class="far fa-file-pdf"></i></span>
         </router-link>
-        <b-button :disabled="cannotCopy(data.item.id)" v-b-tooltip.hover size="sm" class="mx-1" variant="success" title="Copy Science Application for current Call" @click="copyScienceApplication(data.item.id)">
-          <i class="fa fa-copy fa-fw" />
+      </template>
+      <template #cell(copy)="data" v-if="!isSciCollab">
+        <b-button :disabled="cannotCopy(data.item.id)" @click="copyScienceApplication(data.item.id)" variant="link" size="sm" v-b-tooltip.hover title="Copy Science Application as draft for current Call">
+          <b-icon icon="stickies" flip-v shift-v="3" aria-hidden="true"></b-icon>
         </b-button>
       </template>
     </b-table>
@@ -156,7 +158,7 @@ export default {
       ];
     } else {
       draftApplicationFields = [{ key: 'title' }, { key: 'call' }, { key: 'deadline' }, { key: 'status' }, { key: 'preview' }, { key: 'delete' }];
-      submittedApplicationFields = [{ key: 'title' }, { key: 'call' }, { key: 'deadline' }, { key: 'status' }, { key: 'view' }];
+      submittedApplicationFields = [{ key: 'title' }, { key: 'call' }, { key: 'deadline' }, { key: 'status' }, { key: 'view' }, { key: 'copy' }];
     }
     return {
       draftApplicationFields: draftApplicationFields,

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import Vue from 'vue';
 import App from './App.vue';
 import router from './router';
 import store from './store';
-import { BootstrapVue, BIcon, BIconStickies} from 'bootstrap-vue';
+import { BootstrapVue, BIcon, BIconStickies } from 'bootstrap-vue';
 import 'bootstrap';
 import '@/assets/scss/app.scss';
 import $ from 'jquery';
@@ -50,10 +50,7 @@ $.ajax({
 
   // Add the archive token to a request being sent to the archive api or the thumbservice
   $.ajaxPrefilter(function(options, originalOptions, jqXHR) {
-    if (
-      (options.url.startsWith(store.state.urls.archiveApi) || options.url.startsWith(store.state.urls.thumbnailService)) &&
-      store.state.profile
-    ) {
+    if ((options.url.startsWith(store.state.urls.archiveApi) || options.url.startsWith(store.state.urls.thumbnailService)) && store.state.profile) {
       jqXHR.setRequestHeader('Authorization', 'Token ' + store.state.profile.tokens.api_token);
     }
   });

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import Vue from 'vue';
 import App from './App.vue';
 import router from './router';
 import store from './store';
-import BootstrapVue from 'bootstrap-vue';
+import { BootstrapVue, BIcon, BIconStickies} from 'bootstrap-vue';
 import 'bootstrap';
 import '@/assets/scss/app.scss';
 import $ from 'jquery';
@@ -17,6 +17,8 @@ import VueCompositionAPI from '@vue/composition-api';
 
 Vue.use(VueCompositionAPI);
 Vue.use(BootstrapVue);
+Vue.component('BIcon', BIcon);
+Vue.component('BIconStickies', BIconStickies);
 Vue.use(OCSComponentLib);
 
 Vue.config.productionTip = false;

--- a/src/views/Apply.vue
+++ b/src/views/Apply.vue
@@ -68,7 +68,7 @@
         <sci-applications :is-sci-collab="true" :sci-collab-allocations="allocations"></sci-applications>
       </template>
       <h1>Your Proposals</h1>
-      <sci-applications :is-sci-collab="false"></sci-applications>
+      <sci-applications :is-sci-collab="false" :open-call-types="openCallTypes"></sci-applications>
     </b-col>
   </b-row>
 </template>
@@ -115,6 +115,9 @@ export default {
       return _.filter(this.data.results, call => {
         return call.proposal_type === 'COLAB';
       });
+    },
+    openCallTypes: function() {
+      return _.uniqBy(_.map(this.data.results, 'proposal_type'));
     },
     sciencecollaborationallocation: function() {
       return this.$store.state.profile.profile.sciencecollaborationallocation;

--- a/src/views/Compose.vue
+++ b/src/views/Compose.vue
@@ -173,18 +173,18 @@
                 </ocs-custom-field>
               </template>
               <template #target-fields-footer="slotProps">
-                  <!-- This showFractionalRate has a side effect of clearing out the fractional_ephemeris_rate from the extra_params if it doesn't show -->
-                  <span v-show="showFractionalRate(slotProps.data.target)">
-                    <ocs-custom-field
-                      key="fractional_ephemeris_rate"
-                      v-model="slotProps.data.target.extra_params['fractional_ephemeris_rate']"
-                      field="fractional_ephemeris_rate"
-                      label="Fractional Ephemeris Rate"
-                      desc="Fraction of the target's motion that will be used for tracking. Must be a value from 0.0 (Sidereal Tracking) to 1.0 (Target Tracking). See the Getting Started guide for suggestions on how to counter target drift."
-                      :errors="slotProps.data.target.errors"
-                      @input="slotProps.update()"
-                    />
-                  </span>
+                <!-- This showFractionalRate has a side effect of clearing out the fractional_ephemeris_rate from the extra_params if it doesn't show -->
+                <span v-show="showFractionalRate(slotProps.data.target)">
+                  <ocs-custom-field
+                    key="fractional_ephemeris_rate"
+                    v-model="slotProps.data.target.extra_params['fractional_ephemeris_rate']"
+                    field="fractional_ephemeris_rate"
+                    label="Fractional Ephemeris Rate"
+                    desc="Fraction of the target's motion that will be used for tracking. Must be a value from 0.0 (Sidereal Tracking) to 1.0 (Target Tracking). See the Getting Started guide for suggestions on how to counter target drift."
+                    :errors="slotProps.data.target.errors"
+                    @input="slotProps.update()"
+                  />
+                </span>
               </template>
               <template #target-help="slotProps">
                 <archive
@@ -867,7 +867,7 @@ export default {
       }
       for (let instrument in instrumentsData) {
         let configurationTypesToDelete = [];
-        if (instrument === '1M0-NRES-SCICAM'){
+        if (instrument === '1M0-NRES-SCICAM') {
           configurationTypesToDelete.push('ARC', 'LAMP_FLAT');
         }
         for (let configurationType in instrumentsData[instrument].configuration_types) {
@@ -896,8 +896,7 @@ export default {
     showFractionalRate: function(target) {
       if (target.type === 'ORBITAL_ELEMENTS' && !target.scheme.includes('MAJOR_PLANET')) {
         return true;
-      }
-      else if (target.extra_params) {
+      } else if (target.extra_params) {
         delete target.extra_params['fractional_ephemeris_rate'];
       }
       return false;


### PR DESCRIPTION
This goes along with your branch adding the /copy endpoint for sciapps. I tested DDT, Key, Science and they all copied fine, and I think this looks decent enough. I tried making it as a link so it had the orange hover and stuff, but I think that is confusing (especially for accessibility) since it really is a button, not a link like the two view "buttons". I did style the button to be icon only though to match the styling of those view "buttons".

The Copy button is added as the last column of the submitted sciapps section. The Copy button should be greyed out and unclickable if there is no Call of the right type currently active. Otherwise you just click the copy button and the sciapp set will reload and a copy should show up in the draft section.