### PR TITLE
Do not add undefined api token to headers of request to archive API

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -50,7 +50,7 @@ $.ajax({
 
   // Add the archive token to a request being sent to the archive api or the thumbservice
   $.ajaxPrefilter(function(options, originalOptions, jqXHR) {
-    if ((options.url.startsWith(store.state.urls.archiveApi) || options.url.startsWith(store.state.urls.thumbnailService)) && store.state.profile) {
+    if ((options.url.startsWith(store.state.urls.archiveApi) || options.url.startsWith(store.state.urls.thumbnailService)) && store.state.profile.tokens.api_token) {
       jqXHR.setRequestHeader('Authorization', 'Token ' + store.state.profile.tokens.api_token);
     }
   });


### PR DESCRIPTION
When users are logged out, they do not have a profile.tokens.api_token, and this is being sent to the archive API as undefined. This causes auth to fail. In reality, we want this to not send any authorization headers since the user is logged out. 

This matches [the behavior in the archive frontend](https://github.com/observatorycontrolsystem/science-archive-client/blob/d39eeb48f313715ebb726e5bbbd170bb31e49d3a/src/main.js#L46) as well.

Deployed to http://observation-portal-dev.lco.gtn - confirmed that logged in, the auth token is sent, logged out, no auth header/token is sent. 