### PR TITLE
Fix mailto link on homepage

### DIFF
--- a/src/components/RequestgroupsList.vue
+++ b/src/components/RequestgroupsList.vue
@@ -25,7 +25,7 @@
             </router-link>
           </div>
           <h3 class="mt-4">Need help?</h3>
-          <a href="https://lco.global/documentation/">View the documentation</a> or <a href="mailto:scisupport@lco.global">contact support</a>.
+          <a href="https://lco.global/documentation/">View the documentation</a> or <a href="mailto:science-support@lco.global">contact support</a>.
         </center>
       </div>
     </template>


### PR DESCRIPTION
Emily says: Not urgent, but a user alerted me to the fact that the Observation Portal's "Contact Support" link goes to scisupport@lco.global (which is incorrect).  Could someone please change it to science-support@lco.global when they get a second?