### PR TITLE
Fix/blue color

### DIFF
--- a/src/assets/scss/custom-colors.scss
+++ b/src/assets/scss/custom-colors.scss
@@ -1,5 +1,5 @@
 // Updated basic colors
-$blue: #00adef;
+$blue: #065c99;
 $yellow: #ffc107;
 $white: #fff;
 $red: #dc3545;


### PR DESCRIPTION
Alice updated the default LCO blue color to a darker blue on the main website in order to make it contrast better with white text, so update that here.

Before: 
![image](https://user-images.githubusercontent.com/7182533/217047194-0304b082-6cbd-4710-9afd-b4a07c250c03.png)

After: 
![image](https://user-images.githubusercontent.com/7182533/217047263-e2101f93-23d4-4562-9655-77bbfc59066d.png)

I have this deployed to http://observation-portal-dev.lco.gtn