### PR TITLE
Add long term proposal designation

### DIFF
--- a/src/components/EditSciApplication.vue
+++ b/src/components/EditSciApplication.vue
@@ -43,7 +43,17 @@
             field="is-student-tag"
             :label="''"
             :errors="apiValidationErrors.tags"
+            @input="updateTags('student', isStudent)"
             checkbox-option-label="Data from this proposal will be an important component of a PhD thesis"
+          ></basic-custom-field>
+          <basic-custom-field
+            v-model="isLongTerm"
+            field-type="checkbox"
+            field="is-long-term-tag"
+            :label="''"
+            :errors="apiValidationErrors.tags"
+            @input="updateTags('long-term', isLongTerm)"
+            checkbox-option-label="This proposal may be awarded time for multiple semesters, not just the upcoming semester."
           ></basic-custom-field>
           <template v-if="data.proposal_type === 'COLAB'">
             <basic-custom-field
@@ -442,7 +452,7 @@ import BasicCustomField from '@/components/util/BasicCustomField.vue';
 import NotFound from '@/components/NotFound.vue';
 
 export default {
-  name: 'CreateSciApplication',
+  name: 'EditSciApplication',
   components: {
     BasicCustomField,
     NotFound
@@ -484,6 +494,7 @@ export default {
       sciApp: sciAppData.sciApp,
       pdfPath: sciAppData.pdfPath,
       isStudent: sciAppData.isStudent,
+      isLongTerm: sciAppData.isLongTerm,
       clearPdf: false,
       userTableFields: ['email', 'firstName', 'lastName', 'institution'],
       timeRequestFields: [{ key: 'semester', class: 'd-none' }, 'instrumentTypes', 'standardTime', 'rapidResponse', 'timeCritical'],
@@ -603,6 +614,10 @@ export default {
       if (sciApp.tags.includes('student')) {
         isStudent = true;
       }
+      let isLongTerm = false;
+      if (sciApp.tags.includes('long-term')) {
+        isLongTerm = true;
+      }
       if (_.get(sciApp, 'timerequest_set', []).length === 0) {
         sciApp.timerequest_set = [this.getEmptyTimeRequest()];
       }
@@ -612,7 +627,10 @@ export default {
       // `pdfPath` will either be null for a new science application or
       // for an application to be updated where no pdf has been uploaded yet,
       // or it will be the path to an uploaded pdf.
-      return { sciApp: sciApp, pdfPath: initialSciApp.pdf || null, isStudent: isStudent };
+      return { sciApp: sciApp, pdfPath: initialSciApp.pdf || null, isStudent: isStudent, isLongTerm: isLongTerm };
+    },
+    updateTags: function(newTag, checked) {
+      checked ? this.sciApp.tags.push(newTag) : _.pull(this.sciApp.tags, newTag);
     },
     getEmptyTimeRequest: function() {
       return { semester: '', instrument_types: [], std_time: 0, rr_time: 0, tc_time: 0 };
@@ -760,13 +778,7 @@ export default {
         formData.append('coinvestigator_set[' + i + ']last_name', coInvestigators[i].last_name || '');
         formData.append('coinvestigator_set[' + i + ']institution', coInvestigators[i].institution || '');
       }
-      // Add tags onto the form data if there are any
-      let tags = _.remove(_.get(this.sciApp, ['tags'], []), i => {
-        return i !== 'student';
-      });
-      if (this.isStudent) {
-        tags.push('student');
-      }
+      let tags = _.get(this.sciApp, 'tags', []);
       for (let tag of tags) {
         formData.append('tags', tag);
       }

--- a/src/components/EditSciApplication.vue
+++ b/src/components/EditSciApplication.vue
@@ -53,7 +53,7 @@
             :label="''"
             :errors="apiValidationErrors.tags"
             @input="updateTags('long-term', isLongTerm)"
-            checkbox-option-label="This proposal may be awarded time for multiple semesters, not just the upcoming semester."
+            checkbox-option-label="This is a long-term proposal and may be awarded time for up to 3 consecutive semesters."
           ></basic-custom-field>
           <template v-if="data.proposal_type === 'COLAB'">
             <basic-custom-field

--- a/src/views/SemesterAdminTable.vue
+++ b/src/views/SemesterAdminTable.vue
@@ -199,7 +199,14 @@ export default {
           label: 'Instrument Types',
           sortable: true
         },
-
+        {
+          key: 'tags',
+          sortable: true,
+          sortByFormatted: true,
+          formatter: function(value, key, item) {
+            return item.proposal.tags.join(', ');
+          }
+        },
         {
           key: 'std_allocation',
           label: 'Std Alloc',


### PR DESCRIPTION
Nikolaus/Lisa requested that we add a checkbox on the apply page (similar to the "student" checkbox) indicating that a proposal may be awarded time for up to 3 consecutive semesters.

Add this in, and make a few improvements to generalize for additional tags if needed.