### PR TITLE
Fix rows per page dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@vue/composition-api": "^1.7.2",
         "bootstrap": "^4.5.3",
-        "bootstrap-table": "^1.14.2",
+        "bootstrap-table": "~1.19.0",
         "bootstrap-vue": "^2.21.2",
         "chart.js": "^2.8.0",
         "chartjs-plugin-annotation": "^0.5.7",
@@ -4319,11 +4319,12 @@
       }
     },
     "node_modules/bootstrap-table": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.23.4.tgz",
-      "integrity": "sha512-3HHBJzzpg5z03F4eY8AHpLdW26FlzI0hFcmCb+8HRd5CbqLTd4ZJ5dfJUWFE+euU29rr6vkTyhSu44ucueYPDw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.19.0.tgz",
+      "integrity": "sha512-L+USHm3X9FKocx/6yngGu12yF6r6s1Ntuc+hoIK2a2QQJjHw5kcySLiE2HY/9sEaSGAOfPbfQOtBH3uKkcpqEA==",
+      "license": "MIT",
       "peerDependencies": {
-        "jquery": "3"
+        "jquery": "1.9.1 - 3"
       }
     },
     "node_modules/bootstrap-vue": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@vue/composition-api": "^1.7.2",
     "bootstrap": "^4.5.3",
-    "bootstrap-table": "^1.14.2",
+    "bootstrap-table": "~1.19.0",
     "bootstrap-vue": "^2.21.2",
     "chart.js": "^2.8.0",
     "chartjs-plugin-annotation": "^0.5.7",

--- a/src/components/ArchiveTable.vue
+++ b/src/components/ArchiveTable.vue
@@ -59,6 +59,7 @@ export default {
       queryParamsType: '',
       idField: 'id',
       pagination: true,
+      pageList: '[10, 25, 100, All]',
       pageSize: 10,
       buttonsClass: 'outline-secondary',
       classes: 'table table-hover',


### PR DESCRIPTION
At some point after bootstrap-table v1.20, it appears that support for bootstrap<5 was dropped and this broke our rows per page dropdown. Since we were using a caret spec for the dependency, we were all the way up at 1.24.x, so constrain our version to patch versions within 1.19.x.

https://github.com/user-attachments/assets/1a3231d7-fd1c-46a6-aff3-41cab1ded735
