### PR TITLE
Add alert and check for sinistro filter/readout mode combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ In this root directory:
 
 If you are developing locally, you will probably need to set a few variables in your development Observation
 Portal Django local settings file to handle cross site requests. For example, if your frontend is running at
+
 `http://127.0.0.1:8080`, you would set the following:
 
 ```
@@ -48,7 +49,7 @@ CORS_ORIGIN_WHITELIST = [
     'http://127.0.0.1:8080'
 ]
 CSRF_TRUSTED_ORIGINS = [
-    '127.0.0.1:8080'
+    'http://127.0.0.1:8080'
 ]
 ```
 

--- a/src/components/InstrumentConfigForm.vue
+++ b/src/components/InstrumentConfigForm.vue
@@ -77,8 +77,7 @@
     <!-- End of MUSCAT instrument specific fields -->
     <b-alert variant="warning" :show="badFilterReadoutMode">
       <strong>Warning:</strong> This filter/readout mode combination is not eligible for automatic reduction. <br><br>
-      Please contact science support if this
-      combination is required.
+      Please contact <a href="mailto:science-support@lco.global">science support</a> if this combination is required.
     </b-alert>
     <ocs-custom-select
       v-model="instrumentConfig.mode"

--- a/src/components/InstrumentConfigForm.vue
+++ b/src/components/InstrumentConfigForm.vue
@@ -75,6 +75,11 @@
       @input="update"
     />
     <!-- End of MUSCAT instrument specific fields -->
+    <b-alert variant="warning" :show="badFilterReadoutMode">
+      <strong>Warning:</strong> This filter/readout mode combination is not eligible for automatic reduction. <br><br>
+      Please contact science support if this
+      combination is required.
+    </b-alert>
     <ocs-custom-select
       v-model="instrumentConfig.mode"
       field="readout_mode"
@@ -151,6 +156,7 @@
 <script>
 import { toRef } from '@vue/composition-api';
 import { OCSComposable, OCSUtil } from 'ocs-component-lib';
+import _ from 'lodash';
 
 import { lampFlatDefaultExposureTime, arcDefaultExposureTime } from '@/utils';
 
@@ -249,7 +255,8 @@ export default {
           { value: 'SYNCHRONOUS', text: 'Synchronous' },
           { value: 'ASYNCHRONOUS', text: 'Asynchronous' }
         ]
-      }
+      },
+      badFilterReadoutMode: false
     };
   },
   computed: {
@@ -273,6 +280,26 @@ export default {
     }
   },
   watch: {
+    'instrumentConfig.optical_elements.filter': function(value) {
+      this.badFilterReadoutMode = false;
+      if (this.selectedInstrument === '1M0-SCICAM-SINISTRO') {
+        if (this.instrumentConfig.mode === 'central_2k_2x2') {
+          if (_.includes(['u', 'b', 'v', 'r', 'i'], value)) {
+            this.badFilterReadoutMode = true;
+          }
+        }
+      }
+    },
+    'instrumentConfig.mode': function(value) {
+      this.badFilterReadoutMode = false;
+      if (this.selectedInstrument === '1M0-SCICAM-SINISTRO') {
+        if (value === 'central_2k_2x2') {
+          if (_.includes(['u', 'b', 'v', 'r', 'i'], this.instrumentConfig.optical_elements.filter)) {
+            this.badFilterReadoutMode = true;
+          }
+        }
+      }
+    },
     'instrumentConfig.exposure_time': function(value) {
       if (this.selectedInstrument === 'SOAR_TRIPLESPEC') {
         if (value < 7.0) {


### PR DESCRIPTION
This displays a warning for users if they select a filter/readout mode combination that is unable to be automatically reduced.

There's some bespoke logic in here, but I think it's decently minimal and simple to modify as other instruments are added or policy changes.

https://github.com/user-attachments/assets/997ee8b8-44bd-4ab3-957b-dd57fc631472

