### PR TITLE
Improved Co-I Allocation Rounding

### DIFF
--- a/src/views/ProposalDetail.vue
+++ b/src/views/ProposalDetail.vue
@@ -459,9 +459,9 @@ export default {
           timeLimit += result.time_limit;
           timeUsed += result.time_used_by_user;
         }
-        // convert from seconds to hours
-        this.coInvestigatorTimeInformation.timeLimit = Math.floor(timeLimit / 3600);
-        this.coInvestigatorTimeInformation.timeUsed = Math.floor(timeUsed / 3600);
+        // convert from seconds to hours, and round to the nearest tenth of an hour
+        this.coInvestigatorTimeInformation.timeLimit = Math.round((timeLimit / 3600) * 10) / 10;
+        this.coInvestigatorTimeInformation.timeUsed = Math.round((timeUsed / 3600) * 10) / 10;
         this.coInvestigatorTimeInformation.role = 'CI';
       }
     },


### PR DESCRIPTION
A user noticed that his Co-Is could only see how much time was left in their allocation rounded down to the nearest hour, even though one decimal place is displayed.  This meant that if a Co-I had 8.9 hours left, they were led to believe they only had 8.0 hours, which affected their ability to plan their program (see attached screenshot).

I propose that we round to the nearest tenth of an hour to give the user +/- 3 min accuracy in knowing how much time they have left.

![Screenshot 2025-07-06 084125 (1)](https://github.com/user-attachments/assets/9bf369c4-3449-41ff-913c-b38ed3b67958)
