### PR TITLE
flake: update devenv-k8s to v1 channel

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,22 +31,6 @@
         "type": "github"
       }
     },
-    "deploy-repo-template": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1725037657,
-        "narHash": "sha256-p1ZfPG60DqmcUGJX8rkCVFr0Wh7ZVLCn/BoM6IGTbOo=",
-        "ref": "refs/heads/main",
-        "rev": "82058b4c22070bdb386e13b0edadb45742dc3b2e",
-        "revCount": 17,
-        "type": "git",
-        "url": "https://github.com/LCOGT/deploy-repo-template.git"
-      },
-      "original": {
-        "type": "git",
-        "url": "https://github.com/LCOGT/deploy-repo-template.git"
-      }
-    },
     "devenv": {
       "inputs": {
         "cachix": "cachix",
@@ -71,7 +55,6 @@
     },
     "devenv-k8s": {
       "inputs": {
-        "deploy-repo-template": "deploy-repo-template",
         "devenv": "devenv",
         "devenv-root": "devenv-root",
         "flake-parts": "flake-parts_2",
@@ -83,15 +66,16 @@
         "skaffold": "skaffold"
       },
       "locked": {
-        "lastModified": 1741209900,
-        "narHash": "sha256-Io7haS5sxcnHRkyAeY+DEGh2UNajmIbiCjbBJlrr10Q=",
+        "lastModified": 1754519935,
+        "narHash": "sha256-v86wZsc5EcHm65UnmC+F3MrvmChAtYEdYfQ7Zd6Td20=",
         "owner": "LCOGT",
         "repo": "devenv-k8s",
-        "rev": "91d3283881d043087847451b30fc265d8fb1e106",
+        "rev": "1c84d8a0b0bed74206285ca438e277f4cb78583d",
         "type": "github"
       },
       "original": {
         "owner": "LCOGT",
+        "ref": "v1",
         "repo": "devenv-k8s",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Description for the project";
 
   inputs = {
-    devenv-k8s.url = "github:LCOGT/devenv-k8s";
+    devenv-k8s.url = "github:LCOGT/devenv-k8s/v1";
 
     nixpkgs.follows = "devenv-k8s/nixpkgs";
     flake-parts.follows = "devenv-k8s/flake-parts";


### PR DESCRIPTION
Updates:

### Exec[cmd=sed,args=[-i s/devenv-k8s.url = \"github:LCOGT\/devenv-k8s\";/devenv-k8s.url = \"github:LCOGT\/devenv-k8s\/v1\";/g flake.nix]]
Run sed
Running command `sed` with args [-i s/devenv-k8s.url = \"github:LCOGT\/devenv-k8s\";/devenv-k8s.url = \"github:LCOGT\/devenv-k8s\/v1\";/g flake.nix]

### Exec[cmd=nix,args=[flake update devenv-k8s]]
Run nix
Running command `nix` with args [flake update devenv-k8s]