### PR TITLE
Feature/newfirm archive link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "katex": "^0.12.0",
         "lodash": "^4.17.13",
         "moment": "^2.22.1",
-        "ocs-component-lib": "^0.13.3",
+        "ocs-component-lib": "^0.13.4",
         "pdf-lib": "^1.12.0",
         "popper.js": "^1.16.1",
         "vis": "4.19.1",
@@ -13564,9 +13564,9 @@
       "dev": true
     },
     "node_modules/ocs-component-lib": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/ocs-component-lib/-/ocs-component-lib-0.13.3.tgz",
-      "integrity": "sha512-E5/iWMVZEZSuXOiP2ByGlbC2xIbMY/CE0/20h3rdX09AXZOG0oI9rXIb2O6CiPJmBmgdtwqot+5m5voGySok2g==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ocs-component-lib/-/ocs-component-lib-0.13.4.tgz",
+      "integrity": "sha512-X4GujiHSHtSAM0g5kEl83feqZ6Ekr1ufZsNSG056kh3WLJ/Zx5L9qnSy43m1/tz/g0ophkPGxxsOQWwdsQunSw==",
       "license": "GPL-3.0-only",
       "dependencies": {
         "core-js": "^3.6.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "katex": "^0.12.0",
     "lodash": "^4.17.13",
     "moment": "^2.22.1",
-    "ocs-component-lib": "^0.13.3",
+    "ocs-component-lib": "^0.13.4",
     "pdf-lib": "^1.12.0",
     "popper.js": "^1.16.1",
     "vis": "4.19.1",

--- a/src/components/RequestRow.vue
+++ b/src/components/RequestRow.vue
@@ -21,7 +21,7 @@
         <b-col align-self="center" class="text-center">
           <template v-if="requestIsComplete">
             <span v-if="isBlanco">
-              <a href="https://astroarchive.noirlab.edu/portal/search" target="_blank">Search NOIRLab Archive for data</a>
+              <a :href="blancoArchiveUrl" target="_blank">Search NOIRLab Archive for data</a>
             </span>
             <span v-else>
               <b-img v-if="thumbnailUrl" :src="thumbnailUrl" fluid :alt="frame.filename" :title="frame.filename" />
@@ -84,6 +84,10 @@ export default {
       type: Object,
       required: true
     },
+    proposal: {
+      type: String,
+      default: ''
+    },
     link: {
       type: Boolean,
       default: false
@@ -128,6 +132,14 @@ export default {
     isBlanco: function() {
       let instrumentType = _.get(this.request, ['configurations', 0, 'instrument_type']);
       return instrumentType === 'BLANCO_NEWFIRM';
+    },
+    blancoArchiveUrl: function() {
+      let modified = new Date(this.request.modified);
+      let caldat = new Date(modified);
+      if (modified.getHours() < 14) {
+        caldat.setDate(modified.getDate() - 1);
+      }
+      return "https://astroarchive.noirlab.edu/portal/results/proposal/" + this.proposal + "/?caldat=" + caldat.toISOString().split('T')[0];
     },
     archiveDataIsAvailable: function() {
       return this.frame.id ? true : false;

--- a/src/views/Compose.vue
+++ b/src/views/Compose.vue
@@ -729,7 +729,8 @@ export default {
   methods: {
     ditheringAllowed: function(configuration) {
       let instrumentCategory = _.get(this.instruments, [configuration.instrument_type, 'type']);
-      return !this.simpleInterface && instrumentCategory === 'IMAGE' && configuration.instrument_type != 'BLANCO_NEWFIRM';
+      return (!this.simpleInterface && instrumentCategory === 'IMAGE' && configuration.instrument_type != 'BLANCO_NEWFIRM'
+        && configuration.instrument_type != 'SOAR_GHTS_REDCAM_IMAGER' && configuration.instrument_type != 'SOAR_GHTS_BLUECAM_IMAGER');
     },
     mosaicAllowed: function(request) {
       if (request.configurations.length !== 1) {

--- a/src/views/Compose.vue
+++ b/src/views/Compose.vue
@@ -152,13 +152,21 @@
                   @instrument-config-update="slotProps.update"
                 />
               </template>
-              <template #instrument-config-help>
+              <template #instrument-config-help="slotProps">
                 <ul>
                   <li>
                     Try the
                     <a href=" https://exposure-time-calculator.lco.global/" target="_blank">
                       online Exposure Time Calculator.
                     </a>
+                  </li>
+                  <li v-if="newfirmAndTooLong(slotProps.data.position)">
+                    <i
+                      class="fas fa-exclamation-triangle text-warning align-top"
+                      title="Warning"
+                    > With exposure time >=5s, many stars will be saturated. Furthermore, the sky level will be approximately 25% of the saturation level.
+                      The sky level is ~50% of the saturation level for HX and KXs exposures 10s or greater.
+                    </i>
                   </li>
                 </ul>
               </template>
@@ -727,6 +735,13 @@ export default {
     });
   },
   methods: {
+    newfirmAndTooLong: function(position) {
+      let config = this.requestGroup.requests[position.requestIndex].configurations[position.configurationIndex];
+      if (config.instrument_type == 'BLANCO_NEWFIRM' && config.instrument_configs[position.instrumentConfigIndex].exposure_time >= 5.0) {
+        return true;
+      }
+      return false;
+    },
     ditheringAllowed: function(configuration) {
       let instrumentCategory = _.get(this.instruments, [configuration.instrument_type, 'type']);
       return (!this.simpleInterface && instrumentCategory === 'IMAGE' && configuration.instrument_type != 'BLANCO_NEWFIRM'

--- a/src/views/RequestgroupDetail.vue
+++ b/src/views/RequestgroupDetail.vue
@@ -62,7 +62,7 @@
       </b-col>
     </b-row>
     <template v-if="requestDetail">
-      <request-row :request="request" :instruments="instruments" />
+      <request-row :request="request" :instruments="instruments" :proposal="requestgroup.proposal" />
       <request-detail :request="request" />
     </template>
     <template v-else>
@@ -78,7 +78,7 @@
         small
       >
         <template v-slot:cell(requestRow)="data">
-          <request-row :request="data.item" :instruments="instruments" :link="true" />
+          <request-row :request="data.item" :instruments="instruments" :proposal="requestgroup.proposal" :link="true" />
         </template>
       </b-table>
       <b-pagination


### PR DESCRIPTION
This changes the placehold BLANCO archive URL to be a pre-filtered archive URL that filters on the day obs and proposal to get the user to data from their request quicker. Also blocks dithering options for soar imagers and blanco.