### PR TITLE
fix gcr.io/kpt-fn image refs

### DIFF
--- a/k8s/base/deploy-server/Kptfile
+++ b/k8s/base/deploy-server/Kptfile
@@ -20,6 +20,6 @@ upstreamLock:
     commit: c77bb4b345981221b5266fbb7f769c0b5f8d51fc
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-replacements:v0.1.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/apply-replacements:v0.1.1
       configPath: ./fn-replacements.yaml
       name: apply-replacements

--- a/k8s/base/svc-server/Kptfile
+++ b/k8s/base/svc-server/Kptfile
@@ -20,6 +20,6 @@ upstreamLock:
     commit: c77bb4b345981221b5266fbb7f769c0b5f8d51fc
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-replacements:v0.1.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/apply-replacements:v0.1.1
       configPath: ./fn-replacements.yaml
       name: apply-replacements


### PR DESCRIPTION
Updates:

### Regex[pattern=image:\s+(gcr\.io\/kpt-fn\/).+,file=**/Kptfile]
Update **/Kptfile
Updating file(s) `**/Kptfile` using pattern `image:\s+(gcr\.io\/kpt-fn\/).+`

### Regex[pattern=image:\s+(gcr\.io\/kpt-fn\/).+,file=**/*.yaml]
Update **/*.yaml
Updating file(s) `**/*.yaml` using pattern `image:\s+(gcr\.io\/kpt-fn\/).+`