### PR TITLE
Using Archive to Generate Thumbnails in ObsPortal

### DIFF
--- a/src/archive.js
+++ b/src/archive.js
@@ -20,7 +20,7 @@ function downloadZip(frameIds, archiveRoot, archiveToken) {
 }
 
 function downloadAll(requestId, archiveRoot, archiveClientUrl, archiveToken) {
-  $.getJSON(archiveRoot + '/frames/?limit=1000&exclude_configuration_type=GUIDE&request_id=' + requestId, function(data) {
+  $.getJSON(archiveRoot + '/frames/?exclude_configuration_type=GUIDE&request_id=' + requestId, function(data) {
     if (data.count > 1000) {
       alert('Over 1000 products found. Please use ' + archiveClientUrl + ' to download your data');
       return false;

--- a/src/components/ArchiveTable.vue
+++ b/src/components/ArchiveTable.vue
@@ -43,15 +43,9 @@ export default {
     $('#archive-table').bootstrapTable({
       url: null,
       responseHandler: function(res) {
-        console.log('Archive table response: ', res);
         if (res.count > 1000) {
           alert('More than 1000 results found, please view on archive to view all data');
         }
-        that.$store.commit('setFramesForRequest', {
-          requestId: that.requestid,
-          count: res.count,
-          frames: res.results
-        });
         that.$emit('dataLoaded', res.results);
         $('.fixed-table-loading').hide();
         return res.results;
@@ -90,7 +84,6 @@ export default {
           title: 'DATE_OBS',
           sortable: 'true',
           formatter: function(value) {
-            console.log('DATE_OBS value: ', value);
             return OCSUtil.formatDate(value);
           }
         },
@@ -137,18 +130,11 @@ export default {
     },
     refreshTable: function() {
       if (this.requestid) {
-        let that = this;
-        let requestId = this.requestid;
-        $('#archive-table').bootstrapTable('showLoading');
-        this.$store.dispatch('getFramesForRequest', requestId).then(function(frames) {
-          let count = that.$store.state.thumbnails.frameCountsByRequestId[String(requestId)];
-          console.log('count: ', count);
-          if (count > 1000) {
-            alert('More than 1000 results found, please view on archive to view all data');
-          }
-          $('#archive-table').bootstrapTable('load', frames);
-          that.$emit('dataLoaded', frames);
-          $('#archive-table').bootstrapTable('hideLoading');
+        $('#archive-table').bootstrapTable('refresh', {
+          url:
+            this.archiveApiUrl +
+            '/frames/?limit=1000&exclude_configuration_type=GUIDE&include_thumbnails=true&request_id=' +
+            this.requestid
         });
       }
     }

--- a/src/components/ArchiveTable.vue
+++ b/src/components/ArchiveTable.vue
@@ -43,9 +43,15 @@ export default {
     $('#archive-table').bootstrapTable({
       url: null,
       responseHandler: function(res) {
+        console.log('Archive table response: ', res);
         if (res.count > 1000) {
           alert('More than 1000 results found, please view on archive to view all data');
         }
+        that.$store.commit('setFramesForRequest', {
+          requestId: that.requestid,
+          count: res.count,
+          frames: res.results
+        });
         that.$emit('dataLoaded', res.results);
         $('.fixed-table-loading').hide();
         return res.results;
@@ -84,6 +90,7 @@ export default {
           title: 'DATE_OBS',
           sortable: 'true',
           formatter: function(value) {
+            console.log('DATE_OBS value: ', value);
             return OCSUtil.formatDate(value);
           }
         },
@@ -130,8 +137,18 @@ export default {
     },
     refreshTable: function() {
       if (this.requestid) {
-        $('#archive-table').bootstrapTable('refresh', {
-          url: this.archiveApiUrl + '/frames/?limit=1000&exclude_configuration_type=GUIDE&request_id=' + this.requestid
+        let that = this;
+        let requestId = this.requestid;
+        $('#archive-table').bootstrapTable('showLoading');
+        this.$store.dispatch('getFramesForRequest', requestId).then(function(frames) {
+          let count = that.$store.state.thumbnails.frameCountsByRequestId[String(requestId)];
+          console.log('count: ', count);
+          if (count > 1000) {
+            alert('More than 1000 results found, please view on archive to view all data');
+          }
+          $('#archive-table').bootstrapTable('load', frames);
+          that.$emit('dataLoaded', frames);
+          $('#archive-table').bootstrapTable('hideLoading');
         });
       }
     }

--- a/src/components/RequestDetail.vue
+++ b/src/components/RequestDetail.vue
@@ -108,6 +108,7 @@ import { OCSUtil } from 'ocs-component-lib';
 import Thumbnail from '@/components/Thumbnail.vue';
 import ArchiveTable from '@/components/ArchiveTable.vue';
 import AirmassTelescopeStates from '@/components/AirmassTelescopeStates.vue';
+import { getLatestFrame } from '@/archive.js';
 
 Vue.filter('formatDate', function(value) {
   return OCSUtil.formatDate(value);
@@ -146,9 +147,12 @@ export default {
     archiveApiUrl: function() {
       return this.$store.state.urls.archiveApi;
     },
+    thumbnailServiceUrl: function() {
+      return this.$store.state.urls.thumbnailService;
+    },
     colorImage: function() {
       if (this.curFrame) {
-        return this.archiveApiUrl + '/?request_id=' + this.curFrame.request_id + '&width=4000&height=4000&color=true';
+        return this.thumbnailServiceUrl + '/' + this.curFrame.id + '/?width=4000&height=4000&color=true';
       } else {
         return '';
       }
@@ -188,10 +192,6 @@ export default {
     }
   },
   watch: {
-    'request.id': function() {
-      this.resetArchiveData();
-      this.loadLatestFrame();
-    },
     tab: function(tab) {
       if (tab === 'scheduling' && this.observationData.length === 0) {
         this.loadObservationData();
@@ -228,19 +228,11 @@ export default {
     isObjEmpty: function(obj) {
       return $.isEmptyObject(obj);
     },
-    resetArchiveData: function() {
-      this.frames = [];
-      this.curFrame = null;
-      this.loadingColor = false;
-    },
     loadLatestFrame: function() {
       if (this.request.state === 'COMPLETED') {
         let that = this;
-        let requestId = this.request.id;
-        this.$store.dispatch('getLatestFrameForRequest', requestId).then(function(frame) {
-          if (String(that.request.id) === String(requestId)) {
-            that.curFrame = frame;
-          }
+        getLatestFrame(this.request.id, this.archiveApiUrl, function(frame) {
+          that.curFrame = frame;
         });
       }
     },

--- a/src/components/RequestDetail.vue
+++ b/src/components/RequestDetail.vue
@@ -81,6 +81,7 @@
                 Click a row in the data table to preview the file below. Click preview for a larger version.
               </p>
               <thumbnail v-show="curFrame" :frame="curFrame" width="400" height="400" />
+              {{ curFrame.filename }}
               <p v-show="canViewColor && curFrame">
                 RVB frames found.
                 <b-link title="Color Image" @click="viewColorImage"> View color image <i class="fas fa-external-link-alt" /> </b-link>
@@ -107,7 +108,6 @@ import { OCSUtil } from 'ocs-component-lib';
 import Thumbnail from '@/components/Thumbnail.vue';
 import ArchiveTable from '@/components/ArchiveTable.vue';
 import AirmassTelescopeStates from '@/components/AirmassTelescopeStates.vue';
-import { getLatestFrame } from '@/archive.js';
 
 Vue.filter('formatDate', function(value) {
   return OCSUtil.formatDate(value);
@@ -146,21 +146,18 @@ export default {
     archiveApiUrl: function() {
       return this.$store.state.urls.archiveApi;
     },
-    thumbnailServiceUrl: function() {
-      return this.$store.state.urls.thumbnailService;
-    },
     colorImage: function() {
       if (this.curFrame) {
-        return this.thumbnailServiceUrl + '/' + this.curFrame.id + '/?width=4000&height=4000&color=true';
+        return this.archiveApiUrl + '/?request_id=' + this.curFrame.request_id + '&width=4000&height=4000&color=true';
       } else {
         return '';
       }
     },
     configurationRepeatString: function() {
       if (this.request.configuration_repeats > 1) {
-        return "Configurations - " + this.request.configuration_repeats + " repeats";
+        return 'Configurations - ' + this.request.configuration_repeats + ' repeats';
       }
-      return "Configurations";
+      return 'Configurations';
     },
     canViewColor: function() {
       let colorFilters = {
@@ -191,6 +188,10 @@ export default {
     }
   },
   watch: {
+    'request.id': function() {
+      this.resetArchiveData();
+      this.loadLatestFrame();
+    },
     tab: function(tab) {
       if (tab === 'scheduling' && this.observationData.length === 0) {
         this.loadObservationData();
@@ -210,11 +211,7 @@ export default {
   created: function() {
     let that = this;
     this.$store.dispatch('getProfileData').then(() => {
-      if (that.request.state === 'COMPLETED') {
-        getLatestFrame(that.request.id, that.archiveApiUrl, function(frame) {
-          that.curFrame = frame;
-        });
-      }
+      that.loadLatestFrame();
     });
     if (that.request.windows && that.request.windows.length === 0) {
       $.getJSON(that.observationPortalApiUrl + '/api/requests/' + that.request.id + '/observations/', function(observations) {
@@ -230,6 +227,22 @@ export default {
   methods: {
     isObjEmpty: function(obj) {
       return $.isEmptyObject(obj);
+    },
+    resetArchiveData: function() {
+      this.frames = [];
+      this.curFrame = null;
+      this.loadingColor = false;
+    },
+    loadLatestFrame: function() {
+      if (this.request.state === 'COMPLETED') {
+        let that = this;
+        let requestId = this.request.id;
+        this.$store.dispatch('getLatestFrameForRequest', requestId).then(function(frame) {
+          if (String(that.request.id) === String(requestId)) {
+            that.curFrame = frame;
+          }
+        });
+      }
     },
     loadObservationData: function() {
       let that = this;

--- a/src/components/RequestRow.vue
+++ b/src/components/RequestRow.vue
@@ -12,7 +12,12 @@
           <b-row align-h="center">
             <b-button-group>
               <b-button :href="requestApiUrl" variant="outline-secondary"><i class="fa fa-fw fa-code" /> View in API</b-button>
-              <b-button v-if="requestIsComplete && !isBlanco" variant="outline-secondary" :disabled="!archiveDataIsAvailable" @click="downloadAllData">
+              <b-button
+                v-if="requestIsComplete && !isBlanco"
+                variant="outline-secondary"
+                :disabled="!archiveDataIsAvailable"
+                @click="downloadAllData"
+              >
                 <i class="fa fa-fw fa-download" /> Download
               </b-button>
             </b-button-group>
@@ -60,7 +65,7 @@ import $ from 'jquery';
 import _ from 'lodash';
 import { OCSUtil } from 'ocs-component-lib';
 
-import { downloadAll, getLatestFrame } from '@/archive.js';
+import { downloadAll } from '@/archive.js';
 
 export default {
   name: 'RequestRow',
@@ -112,9 +117,6 @@ export default {
     archiveApiUrl: function() {
       return this.$store.state.urls.archiveApi;
     },
-    thumbnailServiceUrl: function() {
-      return this.$store.state.urls.thumbnailService;
-    },
     archiveClientUrl: function() {
       return this.$store.state.urls.archiveClient;
     },
@@ -139,7 +141,7 @@ export default {
       if (modified.getHours() < 14) {
         caldat.setDate(modified.getDate() - 1);
       }
-      return "https://astroarchive.noirlab.edu/portal/results/proposal/" + this.proposal + "/?caldat=" + caldat.toISOString().split('T')[0];
+      return 'https://astroarchive.noirlab.edu/portal/results/proposal/' + this.proposal + '/?caldat=' + caldat.toISOString().split('T')[0];
     },
     archiveDataIsAvailable: function() {
       return this.frame.id ? true : false;
@@ -158,6 +160,15 @@ export default {
       return this.request.state === 'PENDING';
     }
   },
+  watch: {
+    'request.id': function() {
+      this.resetArchiveData();
+      this.loadLatestThumbnail();
+      if (this.request.state === 'PENDING') {
+        this.getPendingDetails();
+      }
+    }
+  },
   created: function() {
     let that = this;
     this.$store.dispatch('getProfileData').then(() => {
@@ -171,30 +182,59 @@ export default {
     downloadAllData: function() {
       downloadAll(this.request.id, this.archiveApiUrl, this.archiveClientUrl, this.$store.state.profile.tokens.api_token);
     },
+    resetArchiveData: function() {
+      this.thumbnailUrl = '';
+      this.thumbnailError = '';
+      this.archiveError = '';
+      this.frame = {};
+      this.schedulingInformation = {
+        found: false,
+        error: ''
+      };
+    },
     loadLatestThumbnail: function() {
       if (this.isBlanco) {
-        this.archiveError = 'Search NOIRLab Archive for data'
-      }
-      else {
-        const thumbnailSize = 75;
+        this.archiveError = 'Search NOIRLab Archive for data';
+      } else {
         let that = this;
-        getLatestFrame(this.request.id, this.archiveApiUrl, function(frame) {
+        let requestId = this.request.id;
+        this.$store.dispatch('getLatestFrameForRequest', requestId).then(function(frame) {
+          if (String(that.request.id) !== String(requestId)) {
+            return;
+          }
           if (!frame) {
             that.archiveError = 'Waiting on data to become available';
           } else {
             that.frame = frame;
-            $.ajax({
-              url: that.thumbnailServiceUrl + '/' + that.frame.id + '/?height=' + thumbnailSize,
-              dataType: 'json'
-            })
-              .done(function(response) {
-                that.thumbnailUrl = response.url;
+            that.$store
+              .dispatch('fetchThumbnailsByRequestId', {
+                requestId: that.frame.request_id,
+                size: 'small'
               })
-              .fail(function() {
-                that.thumbnailError = 'Could not load thumbnail for this file';
+              .then(function(thumbnails) {
+                if (String(that.request.id) === String(requestId)) {
+                  let thumbnail = that.thumbnailForFrame(thumbnails, that.frame.id);
+                  if (thumbnail) {
+                    that.thumbnailUrl = thumbnail.url;
+                  } else {
+                    that.thumbnailError = 'Could not load thumbnail for this file';
+                  }
+                }
+              })
+              .catch(function() {
+                if (String(that.request.id) === String(requestId)) {
+                  that.thumbnailError = 'Could not load thumbnail for this file';
+                }
               });
           }
         });
+      }
+    },
+    thumbnailForFrame: function(thumbnails, frameId) {
+      for (let index in thumbnails) {
+        if (String(thumbnails[index].frame) === String(frameId)) {
+          return thumbnails[index];
+        }
       }
     },
     getPendingDetails: function() {

--- a/src/components/RequestRow.vue
+++ b/src/components/RequestRow.vue
@@ -117,6 +117,9 @@ export default {
     archiveApiUrl: function() {
       return this.$store.state.urls.archiveApi;
     },
+    thumbnailServiceUrl: function() {
+      return this.$store.state.urls.thumbnailService;
+    },
     archiveClientUrl: function() {
       return this.$store.state.urls.archiveClient;
     },
@@ -192,6 +195,28 @@ export default {
         error: ''
       };
     },
+    generateFromService: function(requestId) {
+      let that = this;
+      const thumbnailSize = 75;
+      if (!this.thumbnailServiceUrl) {
+        that.thumbnailError = 'Could not load thumbnail for this file';
+        return;
+      }
+      $.ajax({
+        url: this.thumbnailServiceUrl + '/' + this.frame.id + '/?height=' + thumbnailSize,
+        dataType: 'json'
+      })
+        .done(function(response) {
+          if (String(that.request.id) === String(requestId)) {
+            that.thumbnailUrl = response.url;
+          }
+        })
+        .fail(function() {
+          if (String(that.request.id) === String(requestId)) {
+            that.thumbnailError = 'Could not load thumbnail for this file';
+          }
+        });
+    },
     loadLatestThumbnail: function() {
       if (this.isBlanco) {
         this.archiveError = 'Search NOIRLab Archive for data';
@@ -217,13 +242,13 @@ export default {
                   if (thumbnail) {
                     that.thumbnailUrl = thumbnail.url;
                   } else {
-                    that.thumbnailError = 'Could not load thumbnail for this file';
+                    that.generateFromService(requestId);
                   }
                 }
               })
               .catch(function() {
                 if (String(that.request.id) === String(requestId)) {
-                  that.thumbnailError = 'Could not load thumbnail for this file';
+                  that.generateFromService(requestId);
                 }
               });
           }

--- a/src/components/RequestRow.vue
+++ b/src/components/RequestRow.vue
@@ -65,7 +65,7 @@ import $ from 'jquery';
 import _ from 'lodash';
 import { OCSUtil } from 'ocs-component-lib';
 
-import { downloadAll } from '@/archive.js';
+import { downloadAll, getLatestFrame } from '@/archive.js';
 
 export default {
   name: 'RequestRow',
@@ -163,15 +163,6 @@ export default {
       return this.request.state === 'PENDING';
     }
   },
-  watch: {
-    'request.id': function() {
-      this.resetArchiveData();
-      this.loadLatestThumbnail();
-      if (this.request.state === 'PENDING') {
-        this.getPendingDetails();
-      }
-    }
-  },
   created: function() {
     let that = this;
     this.$store.dispatch('getProfileData').then(() => {
@@ -185,79 +176,48 @@ export default {
     downloadAllData: function() {
       downloadAll(this.request.id, this.archiveApiUrl, this.archiveClientUrl, this.$store.state.profile.tokens.api_token);
     },
-    resetArchiveData: function() {
-      this.thumbnailUrl = '';
-      this.thumbnailError = '';
-      this.archiveError = '';
-      this.frame = {};
-      this.schedulingInformation = {
-        found: false,
-        error: ''
-      };
+    loadLatestThumbnail: function() {
+      if (this.isBlanco) {
+        this.archiveError = 'Search NOIRLab Archive for data';
+        return;
+      }
+      let that = this;
+      getLatestFrame(this.request.id, this.archiveApiUrl, function(frame) {
+        if (!frame) {
+          that.archiveError = 'Waiting on data to become available';
+          return;
+        }
+        that.frame = frame;
+        let thumbnail = that.thumbnailFromFrame(frame, 'small');
+        if (thumbnail) {
+          that.thumbnailUrl = thumbnail.url;
+        } else {
+          that.generateFromService();
+        }
+      });
     },
-    generateFromService: function(requestId) {
+    generateFromService: function() {
       let that = this;
       const thumbnailSize = 75;
-
       $.ajax({
         url: this.thumbnailServiceUrl + '/' + this.frame.id + '/?height=' + thumbnailSize,
         dataType: 'json'
       })
         .done(function(response) {
-          if (String(that.request.id) === String(requestId)) {
-            that.thumbnailUrl = response.url;
-          }
+          that.thumbnailUrl = response.url;
         })
         .fail(function() {
-          if (String(that.request.id) === String(requestId)) {
-            that.thumbnailError = 'Could not load thumbnail for this file';
-          }
+          that.thumbnailError = 'Could not load thumbnail for this file';
         });
     },
-    loadLatestThumbnail: function() {
-      if (this.isBlanco) {
-        this.archiveError = 'Search NOIRLab Archive for data';
-      } else {
-        let that = this;
-        let requestId = this.request.id;
-        this.$store.dispatch('getLatestFrameForRequest', requestId).then(function(frame) {
-          if (String(that.request.id) !== String(requestId)) {
-            return;
-          }
-          if (!frame) {
-            that.archiveError = 'Waiting on data to become available';
-          } else {
-            that.frame = frame;
-            that.$store
-              .dispatch('fetchThumbnailsByRequestId', {
-                requestId: that.frame.request_id,
-                size: 'small'
-              })
-              .then(function(thumbnails) {
-                if (String(that.request.id) === String(requestId)) {
-                  let thumbnail = that.thumbnailForFrame(thumbnails, that.frame.id);
-                  if (thumbnail) {
-                    that.thumbnailUrl = thumbnail.url;
-                  } else {
-                    that.generateFromService(requestId);
-                  }
-                }
-              })
-              .catch(function() {
-                if (String(that.request.id) === String(requestId)) {
-                  that.generateFromService(requestId);
-                }
-              });
-          }
-        });
+    thumbnailFromFrame: function(frame, size) {
+      if (!frame.thumbnails) {
+        return null;
       }
-    },
-    thumbnailForFrame: function(thumbnails, frameId) {
-      for (let index in thumbnails) {
-        if (String(thumbnails[index].frame) === String(frameId)) {
-          return thumbnails[index];
-        }
-      }
+      return frame.thumbnails.find(function(thumbnail) {
+        // Thumbnail objects have no size field; the size is in the basename (e.g. "...-small_thumbnail").
+        return thumbnail.basename && thumbnail.basename.includes(size + '_thumbnail');
+      });
     },
     getPendingDetails: function() {
       let that = this;

--- a/src/components/RequestRow.vue
+++ b/src/components/RequestRow.vue
@@ -198,10 +198,7 @@ export default {
     generateFromService: function(requestId) {
       let that = this;
       const thumbnailSize = 75;
-      if (!this.thumbnailServiceUrl) {
-        that.thumbnailError = 'Could not load thumbnail for this file';
-        return;
-      }
+
       $.ajax({
         url: this.thumbnailServiceUrl + '/' + this.frame.id + '/?height=' + thumbnailSize,
         dataType: 'json'

--- a/src/components/Thumbnail.vue
+++ b/src/components/Thumbnail.vue
@@ -38,10 +38,10 @@ export default {
     };
   },
   computed: {
-      thumbnailServiceUrl: function() {
-        return this.$store.state.urls.thumbnailService;
-      }
-    },
+    thumbnailServiceUrl: function() {
+      return this.$store.state.urls.thumbnailService;
+    }
+  },
   watch: {
     frame: function() {
       this.updateFrame();
@@ -59,26 +59,15 @@ export default {
       }
     },
     fetch: function() {
-      let that = this;
       let frameId = this.frame.id;
-      this.$store
-        .dispatch('fetchThumbnailsByRequestId', {
-          requestId: this.frame.request_id,
-          size: 'small'
-        })
-        .then(function(thumbnails) {
-          if (that.frame && String(that.frame.id) === String(frameId)) {
-            let thumbnail = that.thumbnailForFrame(thumbnails, frameId);
-            if (thumbnail) {
-              that.src = thumbnail.url;
-            } else {
-              that.generateFromService(frameId);
-            }
-          }
-        })
-        .catch(function() {
-          that.generateFromService(frameId);
-        });
+      let thumbnail = this.thumbnailFromFrame(this.frame, 'small');
+      if (thumbnail) {
+        this.src = thumbnail.url;
+      } else {
+        // The archive has no pre-generated thumbnail for this frame, so fall
+        // back to the thumbnail service to generate one on demand.
+        this.generateFromService(frameId);
+      }
     },
     generateFromService: function(frameId) {
       let that = this;
@@ -95,27 +84,24 @@ export default {
     },
     generateLarge: function() {
       let that = this;
-      let frameId = this.frame.id;
       this.loadLarge = true;
-      this.$store
-        .dispatch('fetchThumbnailsByRequestId', {
-          requestId: this.frame.request_id,
-          size: 'small'
-        })
-        .then(function(thumbnails) {
-          let thumbnail = that.thumbnailForFrame(thumbnails, frameId);
-          that.loadLarge = false;
-          if (thumbnail) {
-            window.open(thumbnail.url, '_blank');
-          }
-        });
+      let url = this.thumbnailServiceUrl + '/' + this.frame.id + '/?width=4000&height=4000';
+      $.getJSON(url, function(data) {
+        that.loadLarge = false;
+        window.open(data.url, '_blank');
+      }).fail(function() {
+        that.loadLarge = false;
+      });
     },
-    thumbnailForFrame: function(thumbnails, frameId) {
-      for (let index in thumbnails) {
-        if (String(thumbnails[index].frame) === String(frameId)) {
-          return thumbnails[index];
-        }
+    thumbnailFromFrame: function(frame, size) {
+      // the purpose of using include_thumbnails=true is so that the archive attaches any pre-generated thumbnails to each frame :D
+      if (!frame.thumbnails) {
+        return null;
       }
+      return frame.thumbnails.find(function(thumbnail) {
+        // Thumbnail objects have no size field; the size is in the basename (e.g. "...-small_thumbnail").
+        return thumbnail.basename && thumbnail.basename.includes(size + '_thumbnail');
+      });
     }
   }
 };

--- a/src/components/Thumbnail.vue
+++ b/src/components/Thumbnail.vue
@@ -9,8 +9,6 @@
   </div>
 </template>
 <script>
-import $ from 'jquery';
-
 export default {
   props: {
     frame: {
@@ -37,21 +35,6 @@ export default {
       loadLarge: false
     };
   },
-  computed: {
-    thumbnailServiceUrl: function() {
-      return this.$store.state.urls.thumbnailService;
-    },
-    url: function() {
-      return this.thumbnailServiceUrl + '/' + this.frame.id + '/?width=' + this.width + '&height=' + this.height + '&label=' + this.frame.filename;
-    },
-    largeUrl: function() {
-      if (this.frame) {
-        return this.thumbnailServiceUrl + '/' + this.frame.id + '/?width=4000&height=4000';
-      } else {
-        return '';
-      }
-    }
-  },
   watch: {
     frame: function() {
       this.updateFrame();
@@ -64,24 +47,55 @@ export default {
     updateFrame: function() {
       if (this.frame) {
         this.src = '';
+        this.error = null;
         this.fetch();
       }
     },
     fetch: function() {
       let that = this;
-      $.getJSON(this.url, function(data) {
-        that.src = data.url;
-      }).fail(function() {
-        that.error = 'Could not load thumbnail for this image';
-      });
+      let frameId = this.frame.id;
+      this.$store
+        .dispatch('fetchThumbnailsByRequestId', {
+          requestId: this.frame.request_id,
+          size: 'small'
+        })
+        .then(function(thumbnails) {
+          if (that.frame && String(that.frame.id) === String(frameId)) {
+            let thumbnail = that.thumbnailForFrame(thumbnails, frameId);
+            if (thumbnail) {
+              that.src = thumbnail.url;
+            } else {
+              that.error = 'Could not load thumbnail for this image';
+            }
+          }
+        })
+        .catch(function() {
+          that.error = 'Could not load thumbnail for this image';
+        });
     },
     generateLarge: function() {
       let that = this;
+      let frameId = this.frame.id;
       this.loadLarge = true;
-      $.getJSON(this.largeUrl, function(data) {
-        that.loadLarge = false;
-        window.open(data['url'], '_blank');
-      });
+      this.$store
+        .dispatch('fetchThumbnailsByRequestId', {
+          requestId: this.frame.request_id,
+          size: 'small'
+        })
+        .then(function(thumbnails) {
+          let thumbnail = that.thumbnailForFrame(thumbnails, frameId);
+          that.loadLarge = false;
+          if (thumbnail) {
+            window.open(thumbnail.url, '_blank');
+          }
+        });
+    },
+    thumbnailForFrame: function(thumbnails, frameId) {
+      for (let index in thumbnails) {
+        if (String(thumbnails[index].frame) === String(frameId)) {
+          return thumbnails[index];
+        }
+      }
     }
   }
 };

--- a/src/components/Thumbnail.vue
+++ b/src/components/Thumbnail.vue
@@ -82,10 +82,6 @@ export default {
     },
     generateFromService: function(frameId) {
       let that = this;
-      if (!this.thumbnailServiceUrl) {
-        that.error = 'Could not load thumbnail for this image';
-        return;
-      }
       let url =
         this.thumbnailServiceUrl + '/' + this.frame.id +
         '/?width=' + this.width + '&height=' + this.height + '&label=' + this.frame.filename;

--- a/src/components/Thumbnail.vue
+++ b/src/components/Thumbnail.vue
@@ -9,6 +9,8 @@
   </div>
 </template>
 <script>
+import $ from 'jquery';
+
 export default {
   props: {
     frame: {
@@ -35,6 +37,11 @@ export default {
       loadLarge: false
     };
   },
+  computed: {
+      thumbnailServiceUrl: function() {
+        return this.$store.state.urls.thumbnailService;
+      }
+    },
   watch: {
     frame: function() {
       this.updateFrame();
@@ -65,13 +72,30 @@ export default {
             if (thumbnail) {
               that.src = thumbnail.url;
             } else {
-              that.error = 'Could not load thumbnail for this image';
+              that.generateFromService(frameId);
             }
           }
         })
         .catch(function() {
-          that.error = 'Could not load thumbnail for this image';
+          that.generateFromService(frameId);
         });
+    },
+    generateFromService: function(frameId) {
+      let that = this;
+      if (!this.thumbnailServiceUrl) {
+        that.error = 'Could not load thumbnail for this image';
+        return;
+      }
+      let url =
+        this.thumbnailServiceUrl + '/' + this.frame.id +
+        '/?width=' + this.width + '&height=' + this.height + '&label=' + this.frame.filename;
+      $.getJSON(url, function(data) {
+        if (that.frame && String(that.frame.id) === String(frameId)) {
+          that.src = data.url;
+        }
+      }).fail(function() {
+        that.error = 'Could not load thumbnail for this image';
+      });
     },
     generateLarge: function() {
       let that = this;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import $ from 'jquery';
+import thumbnails from '@/store/thumbnails.js';
 
 Vue.use(Vuex);
 
@@ -100,5 +101,7 @@ export default new Vuex.Store({
       });
     }
   },
-  modules: {}
+  modules: {
+    thumbnails
+  }
 });

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import $ from 'jquery';
-import thumbnails from '@/store/thumbnails.js';
 
 Vue.use(Vuex);
 
@@ -100,8 +99,5 @@ export default new Vuex.Store({
         });
       });
     }
-  },
-  modules: {
-    thumbnails
   }
 });

--- a/src/store/thumbnails.js
+++ b/src/store/thumbnails.js
@@ -1,0 +1,126 @@
+import Vue from 'vue';
+import Vuex from 'vuex';
+import $ from 'jquery';
+
+Vue.use(Vuex);
+
+const THUMBNAIL_DATA = {
+  framesByRequestId: {},
+  frameCountsByRequestId: {},
+  latestFrameByRequestId: {},
+  thumbnailsByRequestIdAndSize: {}
+};
+
+const pendingFramesByRequestId = {};
+const pendingThumbnailsByRequestIdAndSize = {};
+
+function thumbnailKey(requestId, size) {
+  return String(requestId) + ':' + size;
+}
+
+// check why this is not in order
+function getLatestFrame(frames) {
+  return frames[0];
+}
+
+export default {
+  state: THUMBNAIL_DATA,
+  mutations: {
+    setFramesForRequest(state, payload) {
+      let requestId = String(payload.requestId);
+      Vue.set(state.framesByRequestId, requestId, payload.frames);
+      Vue.set(state.frameCountsByRequestId, requestId, payload.count);
+      Vue.set(state.latestFrameByRequestId, requestId, getLatestFrame(payload.frames));
+    },
+    setLatestFrameForRequest(state, payload) {
+      Vue.set(state.latestFrameByRequestId, String(payload.requestId), payload.frame);
+    },
+    setThumbnailsForRequest(state, payload) {
+      Vue.set(state.thumbnailsByRequestIdAndSize, thumbnailKey(payload.requestId, payload.size), payload.thumbnails);
+    }
+  },
+  actions: {
+    getFramesForRequest(storeContext, requestId) {
+      let requestKey = String(requestId);
+      if (requestKey in storeContext.state.framesByRequestId) {
+        return Promise.resolve(storeContext.state.framesByRequestId[requestKey]);
+      }
+      if (pendingFramesByRequestId[requestKey]) {
+        return pendingFramesByRequestId[requestKey];
+      }
+
+      pendingFramesByRequestId[requestKey] = new Promise((resolve, reject) => {
+        $.ajax({
+          url: storeContext.rootState.urls.archiveApi + '/frames/?exclude_configuration_type=GUIDE&request_id=' + requestId,
+          dataType: 'json',
+          success: function(response) {
+            storeContext.commit('setFramesForRequest', {
+              requestId: requestId,
+              count: response.count,
+              frames: response.results
+            });
+            resolve(response.results);
+          },
+          error: function(response) {
+            reject(response);
+          },
+          complete: function() {
+            delete pendingFramesByRequestId[requestKey];
+          }
+        });
+      });
+
+      return pendingFramesByRequestId[requestKey];
+    },
+    getLatestFrameForRequest(storeContext, requestId) {
+      let requestKey = String(requestId);
+      if (requestKey in storeContext.state.latestFrameByRequestId) {
+        return Promise.resolve(storeContext.state.latestFrameByRequestId[requestKey]);
+      }
+      if (requestKey in storeContext.state.framesByRequestId) {
+        let frame = getLatestFrame(storeContext.state.framesByRequestId[requestKey]);
+        storeContext.commit('setLatestFrameForRequest', {
+          requestId: requestId,
+          frame: frame
+        });
+        return Promise.resolve(frame);
+      }
+
+      return storeContext.dispatch('getFramesForRequest', requestId).then(function(frames) {
+        return getLatestFrame(frames);
+      });
+    },
+    fetchThumbnailsByRequestId(context, payload) {
+      let requestKey = thumbnailKey(payload.requestId, payload.size);
+      if (requestKey in context.state.thumbnailsByRequestIdAndSize) {
+        return Promise.resolve(context.state.thumbnailsByRequestIdAndSize[requestKey]);
+      }
+      if (pendingThumbnailsByRequestIdAndSize[requestKey]) {
+        return pendingThumbnailsByRequestIdAndSize[requestKey];
+      }
+
+      pendingThumbnailsByRequestIdAndSize[requestKey] = new Promise((resolve, reject) => {
+        $.ajax({
+          url: context.rootState.urls.archiveApi + '/thumbnails/?request_id=' + payload.requestId + '&size=' + payload.size,
+          dataType: 'json',
+          success: function(response) {
+            context.commit('setThumbnailsForRequest', {
+              requestId: payload.requestId,
+              size: payload.size,
+              thumbnails: response.results
+            });
+            resolve(response.results);
+          },
+          error: function(response) {
+            reject(response);
+          },
+          complete: function() {
+            delete pendingThumbnailsByRequestIdAndSize[requestKey];
+          }
+        });
+      });
+
+      return pendingThumbnailsByRequestIdAndSize[requestKey];
+    }
+  }
+};

--- a/src/views/RequestgroupDetail.vue
+++ b/src/views/RequestgroupDetail.vue
@@ -152,6 +152,11 @@ export default {
       return requestDict;
     }
   },
+  watch: {
+    id: function() {
+      this.loadRequestgroup();
+    }
+  },
   created: function() {
     let that = this;
     // Get the archive token here before the rest of the components are rendered since
@@ -159,15 +164,21 @@ export default {
     // the token is sent.
     this.$store.dispatch('getProfileData').finally(() => {
       that.profileLoaded = true;
-      if (that.requestDetail) {
-        that.getRequestgroupByRequestId();
-      } else {
-        that.getRequestgroupByRequestgroupId();
-      }
+      that.loadRequestgroup();
     });
     this.getInstruments();
   },
   methods: {
+    loadRequestgroup: function() {
+      this.requestgroupLoaded = false;
+      this.requestgroupLoadError = false;
+      this.requestgroupNotFound = false;
+      if (this.requestDetail) {
+        this.getRequestgroupByRequestId();
+      } else {
+        this.getRequestgroupByRequestgroupId();
+      }
+    },
     getInstruments: function() {
       let that = this;
       $.ajax({
@@ -179,11 +190,15 @@ export default {
     },
     getRequestgroupByRequestgroupId: function() {
       let that = this;
+      let requestgroupId = this.id;
       $.ajax({
-        url: this.observationPortalApiUrl + '/api/requestgroups/' + this.id + '/',
+        url: this.observationPortalApiUrl + '/api/requestgroups/' + requestgroupId + '/',
         dataType: 'json'
       })
         .done(function(response) {
+          if (String(that.id) !== String(requestgroupId)) {
+            return;
+          }
           that.requestgroup = response;
           if (response.requests.length === 1) {
             that.$router.replace({
@@ -193,6 +208,9 @@ export default {
           }
         })
         .fail(function(response) {
+          if (String(that.id) !== String(requestgroupId)) {
+            return;
+          }
           if (response.status === 404) {
             that.requestgroupNotFound = true;
           } else {
@@ -200,16 +218,22 @@ export default {
           }
         })
         .always(function() {
-          that.requestgroupLoaded = true;
+          if (String(that.id) === String(requestgroupId)) {
+            that.requestgroupLoaded = true;
+          }
         });
     },
     getRequestgroupByRequestId: function() {
       let that = this;
+      let requestId = this.id;
       $.ajax({
-        url: this.observationPortalApiUrl + '/api/requestgroups/' + '?request_id=' + this.id,
+        url: this.observationPortalApiUrl + '/api/requestgroups/' + '?request_id=' + requestId,
         dataType: 'json'
       })
         .done(function(response) {
+          if (String(that.id) !== String(requestId)) {
+            return;
+          }
           if (response.results.length > 0) {
             that.requestgroup = response.results[0];
           } else {
@@ -217,6 +241,9 @@ export default {
           }
         })
         .fail(function(response) {
+          if (String(that.id) !== String(requestId)) {
+            return;
+          }
           if (response.status === 404) {
             that.requestgroupNotFound = true;
           } else {
@@ -224,7 +251,9 @@ export default {
           }
         })
         .always(function() {
-          that.requestgroupLoaded = true;
+          if (String(that.id) === String(requestId)) {
+            that.requestgroupLoaded = true;
+          }
         });
     },
     cancelRequestGroup: function() {


### PR DESCRIPTION
Modified the frontend of the observation portal to use the thumbnail archive to avoid unnecessary generation of preexisting thumbnails. Added the Thumbnail Service as the fallback in case the archive doesn't have the required thumbnail.