### PR TITLE
Fix/thumbnails

### DIFF
--- a/src/archive.js
+++ b/src/archive.js
@@ -35,7 +35,7 @@ function downloadAll(requestId, archiveRoot, archiveClientUrl, archiveToken) {
 
 function getLatestFrame(requestId, archiveRoot, callback) {
   $.ajax({
-    url: archiveRoot + '/frames/?ordering=-id&limit=1&request_id=' + requestId,
+    url: archiveRoot + '/frames/?include_thumbnails=true&ordering=-id&limit=1&request_id=' + requestId,
     dataType: 'json'
   }).done(function(response) {
     callback(response.results[0]);

--- a/src/components/ArchiveTable.vue
+++ b/src/components/ArchiveTable.vue
@@ -131,7 +131,7 @@ export default {
     refreshTable: function() {
       if (this.requestid) {
         $('#archive-table').bootstrapTable('refresh', {
-          url: this.archiveApiUrl + '/frames/?limit=1000&exclude_configuration_type=GUIDE&request_id=' + this.requestid
+          url: this.archiveApiUrl + '/frames/?limit=1000&include_thumbnails=true&exclude_configuration_type=GUIDE&request_id=' + this.requestid
         });
       }
     }

--- a/src/components/RequestRow.vue
+++ b/src/components/RequestRow.vue
@@ -190,7 +190,7 @@ export default {
               const thumbnails = that.frame.thumbnails;
               const smallThumbnail = thumbnails.find(t => t.size === 'small');
               that.thumbnailUrl = smallThumbnail.url;
-            } else if (that.frame && that.frame.thumbnails.length === 0) {
+            } else {
               const thumbnailSize = 75;
               $.ajax({
                 url: that.thumbnailServiceUrl + '/' + that.frame.id + '/?height=' + thumbnailSize,

--- a/src/components/RequestRow.vue
+++ b/src/components/RequestRow.vue
@@ -190,6 +190,9 @@ export default {
               const thumbnails = that.frame.thumbnails;
               const smallThumbnail = thumbnails.find(t => t.size === 'small');
               that.thumbnailUrl = smallThumbnail.url;
+              if (!smallThumbnail) {
+                that.thumbnailUrl = thumbnails[0].url;
+              }
             } else {
               const thumbnailSize = 75;
               $.ajax({

--- a/src/components/RequestRow.vue
+++ b/src/components/RequestRow.vue
@@ -12,7 +12,12 @@
           <b-row align-h="center">
             <b-button-group>
               <b-button :href="requestApiUrl" variant="outline-secondary"><i class="fa fa-fw fa-code" /> View in API</b-button>
-              <b-button v-if="requestIsComplete && !isBlanco" variant="outline-secondary" :disabled="!archiveDataIsAvailable" @click="downloadAllData">
+              <b-button
+                v-if="requestIsComplete && !isBlanco"
+                variant="outline-secondary"
+                :disabled="!archiveDataIsAvailable"
+                @click="downloadAllData"
+              >
                 <i class="fa fa-fw fa-download" /> Download
               </b-button>
             </b-button-group>
@@ -139,7 +144,7 @@ export default {
       if (modified.getHours() < 14) {
         caldat.setDate(modified.getDate() - 1);
       }
-      return "https://astroarchive.noirlab.edu/portal/results/proposal/" + this.proposal + "/?caldat=" + caldat.toISOString().split('T')[0];
+      return 'https://astroarchive.noirlab.edu/portal/results/proposal/' + this.proposal + '/?caldat=' + caldat.toISOString().split('T')[0];
     },
     archiveDataIsAvailable: function() {
       return this.frame.id ? true : false;
@@ -173,26 +178,31 @@ export default {
     },
     loadLatestThumbnail: function() {
       if (this.isBlanco) {
-        this.archiveError = 'Search NOIRLab Archive for data'
-      }
-      else {
-        const thumbnailSize = 75;
+        this.archiveError = 'Search NOIRLab Archive for data';
+      } else {
         let that = this;
         getLatestFrame(this.request.id, this.archiveApiUrl, function(frame) {
           if (!frame) {
             that.archiveError = 'Waiting on data to become available';
           } else {
             that.frame = frame;
-            $.ajax({
-              url: that.thumbnailServiceUrl + '/' + that.frame.id + '/?height=' + thumbnailSize,
-              dataType: 'json'
-            })
-              .done(function(response) {
-                that.thumbnailUrl = response.url;
+            if (that.frame.thumbnails.length > 0) {
+              const thumbnails = that.frame.thumbnails;
+              const smallThumbnail = thumbnails.find(t => t.size === 'small');
+              that.thumbnailUrl = smallThumbnail.url;
+            } else if (that.frame && that.frame.thumbnails.length === 0) {
+              const thumbnailSize = 75;
+              $.ajax({
+                url: that.thumbnailServiceUrl + '/' + that.frame.id + '/?height=' + thumbnailSize,
+                dataType: 'json'
               })
-              .fail(function() {
-                that.thumbnailError = 'Could not load thumbnail for this file';
-              });
+                .done(function(response) {
+                  that.thumbnailUrl = response.url;
+                })
+                .fail(function() {
+                  that.thumbnailError = 'Could not load thumbnail for this file';
+                });
+            }
           }
         });
       }

--- a/src/components/Thumbnail.vue
+++ b/src/components/Thumbnail.vue
@@ -44,7 +44,7 @@ export default {
     url: function() {
       return this.thumbnailServiceUrl + '/' + this.frame.id + '/?width=' + this.width + '&height=' + this.height + '&label=' + this.frame.filename;
     },
-    largelUrl: function() {
+    largeUrl: function() {
       if (this.frame) {
         return this.thumbnailServiceUrl + '/' + this.frame.id + '/?width=4000&height=4000';
       } else {

--- a/src/components/Thumbnail.vue
+++ b/src/components/Thumbnail.vue
@@ -95,6 +95,13 @@ export default {
         that.error = 'Could not load thumbnail for this image';
       });
     },
+    openLargeThumbnailUrl: async function(url) {
+      const response = await fetch(url);
+      const blob = await response.blob();
+      const imageBlob = new Blob([blob], { type: 'image/jpeg' });
+      const blobUrl = URL.createObjectURL(imageBlob);
+      window.open(blobUrl, '_blank');
+    },
     generateLarge: function() {
       let that = this;
       if (!this.largeUrl) {
@@ -102,12 +109,12 @@ export default {
       }
 
       if (this.hasLargeThumbnail) {
-        window.open(this.largeUrl, '_blank');
+        this.openLargeThumbnailUrl(this.largeUrl);
       } else {
         this.loadLarge = true;
         $.getJSON(this.largeUrl, function(data) {
           that.loadLarge = false;
-          window.open(data.url, '_blank');
+          that.openLargeThumbnailUrl(data.url);
         }).fail(function() {
           that.loadLarge = false;
           that.error = 'Could not generate large thumbnail for this image';

--- a/src/components/Thumbnail.vue
+++ b/src/components/Thumbnail.vue
@@ -44,7 +44,7 @@ export default {
     url: function() {
       return this.thumbnailServiceUrl + '/' + this.frame.id + '/?width=' + this.width + '&height=' + this.height + '&label=' + this.frame.filename;
     },
-    largeUrl: function() {
+    largelUrl: function() {
       if (this.frame) {
         return this.thumbnailServiceUrl + '/' + this.frame.id + '/?width=4000&height=4000';
       } else {
@@ -69,11 +69,18 @@ export default {
     },
     fetch: function() {
       let that = this;
-      $.getJSON(this.url, function(data) {
-        that.src = data.url;
-      }).fail(function() {
-        that.error = 'Could not load thumbnail for this image';
-      });
+      const frame = that.frame;
+      const thumbnails = frame.thumbnails;
+      if (thumbnails.length > 0) {
+        const smallThumbnail = thumbnails.find(t => t.size === 'small');
+        that.src = smallThumbnail.url;
+      } else {
+        $.getJSON(this.url, function(data) {
+          that.src = data.url;
+        }).fail(function() {
+          that.error = 'Could not load thumbnail for this image';
+        });
+      }
     },
     generateLarge: function() {
       let that = this;

--- a/src/components/Thumbnail.vue
+++ b/src/components/Thumbnail.vue
@@ -44,12 +44,22 @@ export default {
     url: function() {
       return this.thumbnailServiceUrl + '/' + this.frame.id + '/?width=' + this.width + '&height=' + this.height + '&label=' + this.frame.filename;
     },
+    hasLargeThumbnail: function() {
+      const thumbnails = this.frame && Array.isArray(this.frame.thumbnails) ? this.frame.thumbnails : [];
+      return thumbnails.some(t => t.size === 'large' && t.url);
+    },
     largeUrl: function() {
-      if (this.frame) {
-        return this.thumbnailServiceUrl + '/' + this.frame.id + '/?width=4000&height=4000';
-      } else {
-        return '';
+      if (!this.frame) {
+        return null;
       }
+
+      const thumbnails = Array.isArray(this.frame.thumbnails) ? this.frame.thumbnails : [];
+      const largeThumbnail = thumbnails.find(t => t.size === 'large' && t.url);
+      if (largeThumbnail) {
+        return largeThumbnail.url;
+      }
+
+      return this.thumbnailServiceUrl + '/' + this.frame.id + '/?width=4000&height=4000';
     }
   },
   watch: {
@@ -70,25 +80,39 @@ export default {
     fetch: function() {
       let that = this;
       const frame = that.frame;
-      const thumbnails = frame.thumbnails;
+      const thumbnails = Array.isArray(frame.thumbnails) ? frame.thumbnails : [];
       if (thumbnails.length > 0) {
         const smallThumbnail = thumbnails.find(t => t.size === 'small');
-        that.src = smallThumbnail.url;
-      } else {
-        $.getJSON(this.url, function(data) {
-          that.src = data.url;
-        }).fail(function() {
-          that.error = 'Could not load thumbnail for this image';
-        });
+        if (smallThumbnail && smallThumbnail.url) {
+          that.src = smallThumbnail.url;
+          return;
+        }
       }
+
+      $.getJSON(this.url, function(data) {
+        that.src = data.url;
+      }).fail(function() {
+        that.error = 'Could not load thumbnail for this image';
+      });
     },
     generateLarge: function() {
       let that = this;
-      this.loadLarge = true;
-      $.getJSON(this.largeUrl, function(data) {
-        that.loadLarge = false;
-        window.open(data['url'], '_blank');
-      });
+      if (!this.largeUrl) {
+        return;
+      }
+
+      if (this.hasLargeThumbnail) {
+        window.open(this.largeUrl, '_blank');
+      } else {
+        this.loadLarge = true;
+        $.getJSON(this.largeUrl, function(data) {
+          that.loadLarge = false;
+          window.open(data.url, '_blank');
+        }).fail(function() {
+          that.loadLarge = false;
+          that.error = 'Could not generate large thumbnail for this image';
+        });
+      }
     }
   }
 };


### PR DESCRIPTION
## Feature and Fix: use archive thumbnails endpoint instead of thumbnail service

**Background:**
We were using the thumbnail service to generate thumbnails on the fly instead of the thumbnails endpoint. This has now been updated and thumbnail service is now a fallback

No store needed :)


### VISUALS
**Uses thumbnail endpoint to generate thumbnails. No re-request needed**

https://github.com/user-attachments/assets/8f50b6df-9637-4597-9557-b9f1c595defc



**Uses thumbnail services when thumbnail endpoint fails to return**

https://github.com/user-attachments/assets/8694af9c-aacc-4564-8b4a-a56060667567



